### PR TITLE
Introduce base classes for canvas and palette components

### DIFF
--- a/src/behaviors/useComponentTemplates.ts
+++ b/src/behaviors/useComponentTemplates.ts
@@ -1,25 +1,16 @@
 import { useState, useEffect } from 'react';
-
-export interface ComponentTemplate {
-  id: string;
-  name: string;
-  icon: string;
-  description: string;
-  category: string;
-  template: {
-    type: string;
-    defaultSize: { width: number; height: number };
-    properties: Record<string, any>;
-  };
-}
+import {
+  MarketplaceComponent,
+  MarketplaceComponentOptions,
+} from '../types/component-base';
 
 export interface ComponentTemplatesData {
-  templates: ComponentTemplate[];
+  templates: MarketplaceComponentOptions[];
   categories: string[];
 }
 
 interface UseComponentTemplatesResult {
-  templates: ComponentTemplate[];
+  templates: MarketplaceComponent[];
   categories: string[];
   loading: boolean;
   error: string | null;
@@ -27,41 +18,37 @@ interface UseComponentTemplatesResult {
 }
 
 // Default fallback templates in case loading fails
-const defaultTemplates: ComponentTemplate[] = [
-  {
+const defaultTemplates: MarketplaceComponent[] = [
+  new MarketplaceComponent({
     id: 'text',
     name: 'Text',
     icon: '📝',
     description: 'Text component for labels and content',
     category: 'Basic',
-    template: {
-      type: 'text',
-      defaultSize: { width: 200, height: 40 },
-      properties: {
-        text: 'Sample Text',
-        fontSize: 16,
-        fontFamily: 'Arial',
-        color: '#000000'
-      }
-    }
-  },
-  {
+    type: 'text',
+    defaultSize: { width: 200, height: 40 },
+    properties: {
+      text: 'Sample Text',
+      fontSize: 16,
+      fontFamily: 'Arial',
+      color: '#000000',
+    },
+  }),
+  new MarketplaceComponent({
     id: 'button',
     name: 'Button',
     icon: '🔘',
     description: 'Interactive button component',
     category: 'Basic',
-    template: {
-      type: 'button',
-      defaultSize: { width: 120, height: 40 },
-      properties: {
-        text: 'Button',
-        backgroundColor: '#3b82f6',
-        color: '#ffffff',
-        borderRadius: 6
-      }
-    }
-  }
+    type: 'button',
+    defaultSize: { width: 120, height: 40 },
+    properties: {
+      text: 'Button',
+      backgroundColor: '#3b82f6',
+      color: '#ffffff',
+      borderRadius: 6,
+    },
+  }),
 ];
 
 const defaultCategories = ['All', 'Basic', 'Layout', 'Form', 'Media'];
@@ -76,7 +63,7 @@ const defaultCategories = ['All', 'Basic', 'Layout', 'Form', 'Media'];
 export const useComponentTemplates = (
   templateUrl: string = '/assets/component-templates.json'
 ): UseComponentTemplatesResult => {
-  const [templates, setTemplates] = useState<ComponentTemplate[]>(defaultTemplates);
+  const [templates, setTemplates] = useState<MarketplaceComponent[]>(defaultTemplates);
   const [categories, setCategories] = useState<string[]>(defaultCategories);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -105,12 +92,15 @@ export const useComponentTemplates = (
 
       // Validate each template has required fields
       for (const template of data.templates) {
-        if (!template.id || !template.name || !template.template) {
-          throw new Error(`Invalid template structure: template missing required fields (id, name, template)`);
+        if (!template.id || !template.name || !template.type) {
+          throw new Error(
+            `Invalid template structure: template missing required fields (id, name, type)`
+          );
         }
       }
 
-      setTemplates(data.templates);
+      const mapped = data.templates.map((t) => new MarketplaceComponent(t));
+      setTemplates(mapped);
       setCategories(data.categories);
     } catch (err) {
       console.warn('Failed to load external component templates, using defaults:', err);

--- a/src/components/component-palette/component.tsx
+++ b/src/components/component-palette/component.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { EditorTheme } from '../../types/editor-types';
-import { useComponentTemplates, ComponentTemplate } from '../../behaviors/useComponentTemplates';
+import { useComponentTemplates } from '../../behaviors/useComponentTemplates';
+import { MarketplaceComponent } from '../../types/component-base';
 
 interface ComponentPaletteProps {
   theme: EditorTheme;
@@ -34,12 +35,12 @@ export const ComponentPalette: React.FC<ComponentPaletteProps> = ({
     return matchesCategory && matchesSearch;
   });
 
-  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, component: ComponentTemplate) => {
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, component: MarketplaceComponent) => {
     e.dataTransfer.setData('application/json', JSON.stringify(component.template));
     e.dataTransfer.effectAllowed = 'copy';
   };
 
-  const handleComponentClick = (component: ComponentTemplate) => {
+  const handleComponentClick = (component: MarketplaceComponent) => {
     // For touch devices, clicking will add the component to the canvas
     console.log('Add component to canvas:', component);
   };

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import { EditorTheme, CanvasState, EditorComponent } from '../../types/editor-types';
+import { EditorTheme, CanvasState } from '../../types/editor-types';
+import { BaseComponent } from '../../types/component-base';
 
 interface PinchState {
   startDistance: number;
@@ -37,7 +38,7 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     historyIndex: -1
   });
 
-  const [components, setComponents] = useState<EditorComponent[]>([]);
+  const [components, setComponents] = useState<BaseComponent[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const [, setIsResizing] = useState(false);
   const [lastTouch, setLastTouch] = useState<PinchState | null>(null);
@@ -74,7 +75,7 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     };
   }, []);
 
-  const renderComponent = useCallback((component: EditorComponent) => {
+  const renderComponent = useCallback((component: BaseComponent) => {
     const ctx = ctxRef.current;
     if (!ctx) return;
 
@@ -365,7 +366,7 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
   useEffect(() => {
     if (components.length === 0) {
       setComponents([
-        {
+        new BaseComponent({
           id: '1',
           type: 'text',
           name: 'Text',
@@ -373,10 +374,10 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
           properties: {
             text: 'Sample Text Component',
             fontSize: 16,
-            color: theme === 'dark' ? '#f8fafc' : '#1e293b'
-          }
-        },
-        {
+            color: theme === 'dark' ? '#f8fafc' : '#1e293b',
+          },
+        }),
+        new BaseComponent({
           id: '2',
           type: 'button',
           name: 'Button',
@@ -384,16 +385,16 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
           properties: {
             text: 'Button',
             backgroundColor: '#3b82f6',
-            color: '#ffffff'
-          }
-        },
-        {
+            color: '#ffffff',
+          },
+        }),
+        new BaseComponent({
           id: '3',
           type: 'image',
           name: 'Image',
           bounds: { x: 100, y: 150, width: 150, height: 100 },
-          properties: {}
-        }
+          properties: {},
+        }),
       ]);
     }
   }, [components.length, theme]);

--- a/src/types/component-base.ts
+++ b/src/types/component-base.ts
@@ -1,0 +1,77 @@
+import type { Bounds, Size } from "./editor-types";
+export interface BaseComponentOptions {
+  id: string;
+  type: string;
+  name: string;
+  bounds: Bounds;
+  properties?: Record<string, any>;
+  zIndex?: number;
+  parent?: string;
+  children?: BaseComponent[];
+}
+
+export class BaseComponent {
+  id: string;
+  type: string;
+  name: string;
+  bounds: Bounds;
+  properties: Record<string, any>;
+  zIndex?: number;
+  parent?: string;
+  children?: BaseComponent[];
+
+  constructor(opts: BaseComponentOptions) {
+    this.id = opts.id;
+    this.type = opts.type;
+    this.name = opts.name;
+    this.bounds = opts.bounds;
+    this.properties = opts.properties ?? {};
+    this.zIndex = opts.zIndex;
+    this.parent = opts.parent;
+    this.children = opts.children as BaseComponent[] | undefined;
+  }
+
+  updateProperties(props: Record<string, any>): void {
+    this.properties = { ...this.properties, ...props };
+  }
+}
+
+export interface MarketplaceComponentOptions extends Omit<BaseComponentOptions, 'bounds'> {
+  icon: string;
+  category: string;
+  description: string;
+  defaultSize: Size;
+}
+
+export class MarketplaceComponent extends BaseComponent {
+  icon: string;
+  category: string;
+  description: string;
+  defaultSize: Size;
+
+  constructor(opts: MarketplaceComponentOptions) {
+    super({
+      id: opts.id,
+      type: opts.type,
+      name: opts.name,
+      bounds: { x: 0, y: 0, width: opts.defaultSize.width, height: opts.defaultSize.height },
+      properties: opts.properties,
+      zIndex: opts.zIndex,
+      parent: opts.parent,
+      children: opts.children,
+    });
+    this.icon = opts.icon;
+    this.category = opts.category;
+    this.description = opts.description;
+    this.defaultSize = opts.defaultSize;
+  }
+
+  get template() {
+    return {
+      type: this.type,
+      defaultSize: this.defaultSize,
+      properties: { ...this.properties },
+    };
+  }
+}
+

--- a/src/types/editor-types.ts
+++ b/src/types/editor-types.ts
@@ -1,3 +1,4 @@
+import type { BaseComponent } from "./component-base";
 export type EditorTheme = 'light' | 'dark';
 
 export interface Point {
@@ -62,8 +63,8 @@ export interface CanvasState {
   zoom: number;
   pan: Point;
   selectedComponents: string[];
-  clipboard: EditorComponent[];
-  history: EditorComponent[][];
+  clipboard: BaseComponent[];
+  history: BaseComponent[][];
   historyIndex: number;
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,5 @@
-import { EditorComponent, Point, TouchGesture } from '../types/editor-types';
+import { Point, TouchGesture } from '../types/editor-types';
+import { BaseComponent } from '../types/component-base';
 
 /**
  * Utility functions for touch gesture recognition
@@ -172,30 +173,37 @@ export class ComponentHelper {
     return `component-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
   }
 
-  static createComponent(type: string, bounds: { x: number; y: number; width: number; height: number }, properties: Record<string, any> = {}): EditorComponent {
-    return {
+  static createComponent(
+    type: string,
+    bounds: { x: number; y: number; width: number; height: number },
+    properties: Record<string, any> = {}
+  ): BaseComponent {
+    return new BaseComponent({
       id: this.generateId(),
       type,
       name: `${type.charAt(0).toUpperCase() + type.slice(1)} Component`,
       bounds,
       properties,
       children: [],
-      parent: undefined
-    };
+      parent: undefined,
+    });
   }
 
-  static duplicateComponent(component: EditorComponent, offset: Point = { x: 20, y: 20 }): EditorComponent {
-    const duplicate: EditorComponent = {
+  static duplicateComponent(
+    component: BaseComponent,
+    offset: Point = { x: 20, y: 20 }
+  ): BaseComponent {
+    const duplicate = new BaseComponent({
       ...component,
       id: this.generateId(),
       bounds: {
         ...component.bounds,
         x: component.bounds.x + offset.x,
-        y: component.bounds.y + offset.y
+        y: component.bounds.y + offset.y,
       },
       properties: { ...component.properties },
-      children: component.children?.map(child => this.duplicateComponent(child, offset))
-    };
+      children: component.children?.map((child) => this.duplicateComponent(child, offset)),
+    });
 
     return duplicate;
   }


### PR DESCRIPTION
## Summary
- add `BaseComponent` and `MarketplaceComponent` classes
- use `MarketplaceComponent` in component palette hook
- refactor component palette and canvas to use base classes
- update helper utilities
- adjust editor types to reference new base classes

## Testing
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d2b243448331988246e7e684223e