### PR TITLE
Fix lint and golden layout

### DIFF
--- a/src/components/component-palette/component.stories.tsx
+++ b/src/components/component-palette/component.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ComponentPalette } from './component';
 
 const meta: Meta<typeof ComponentPalette> = {

--- a/src/components/control-panel/control-panel.stories.tsx
+++ b/src/components/control-panel/control-panel.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ControlPanel } from './component';
 
 const meta: Meta<typeof ControlPanel> = {

--- a/src/components/editor-app/component.stories.tsx
+++ b/src/components/editor-app/component.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EditorApp } from './component';
 
 const meta: Meta<typeof EditorApp> = {

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -34,9 +34,26 @@ export const EditorApp: React.FC = () => {
       root: {
         type: 'row',
         content: [
-          { type: 'component', componentType: 'palette', title: 'Components' },
-          { type: 'component', componentType: 'canvas', title: 'Canvas' },
-          { type: 'component', componentType: 'controls', title: 'Properties' }
+          {
+            type: 'component',
+            componentType: 'palette',
+            title: 'Components',
+            isClosable: true
+          },
+          {
+            type: 'component',
+            componentType: 'canvas',
+            title: 'Canvas',
+            isClosable: false,
+            reorderEnabled: false,
+            header: { popout: false, dock: false, maximise: false, close: undefined }
+          },
+          {
+            type: 'component',
+            componentType: 'controls',
+            title: 'Properties',
+            isClosable: true
+          }
         ]
       }
     };

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -46,7 +46,7 @@ export const EditorApp: React.FC = () => {
             title: 'Canvas',
             isClosable: false,
             reorderEnabled: false,
-            header: { popout: false, dock: false, maximise: false, close: undefined }
+            header: { popout: false, dock: false, maximise: false, close: false }
           },
           {
             type: 'component',

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -59,8 +59,8 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
 
       canvas.width = rect.width * devicePixelRatio;
       canvas.height = rect.height * devicePixelRatio;
-      canvas.style.width = rect.width + 'px';
-      canvas.style.height = rect.height + 'px';
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
 
       if (ctx) {
         ctx.scale(devicePixelRatio, devicePixelRatio);
@@ -69,9 +69,12 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
 
     resizeCanvas();
     window.addEventListener('resize', resizeCanvas);
+    const observer = new ResizeObserver(resizeCanvas);
+    observer.observe(container);
 
     return () => {
       window.removeEventListener('resize', resizeCanvas);
+      observer.disconnect();
     };
   }, []);
 

--- a/src/components/editor-canvas/editor-canvas.stories.tsx
+++ b/src/components/editor-canvas/editor-canvas.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EditorCanvas } from './component';
 
 const meta: Meta<typeof EditorCanvas> = {

--- a/src/components/toolbar/toolbar.stories.tsx
+++ b/src/components/toolbar/toolbar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EditorToolbar } from './component';
 
 const meta: Meta<typeof EditorToolbar> = {


### PR DESCRIPTION
## Summary
- fix storybook import lint errors
- resize canvas using ResizeObserver
- restrict canvas panel options so it can't be docked or closed
- adjust golden-layout config so other panels remain dockable

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e23de59083318adf317cda12924d