### PR TITLE
Remove Golden Layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "golden-layout": "^2.6.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -8291,12 +8290,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/golden-layout": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/golden-layout/-/golden-layout-2.6.0.tgz",
-      "integrity": "sha512-sIVQCiRWOymHbVD1Aw/T9/ijbPYAVGBlgGYd1N9MRKfcyBNSpjr87Vg9nSHm+RCT8ELrvK8IJYJV0QRJuVUkCQ==",
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "golden-layout": "^2.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.0",
+    "@storybook/addon-docs": "^9.0.12",
     "@storybook/react-vite": "^9.0.12",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -57,6 +57,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-storybook": "9.0.12",
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
     "jsdom": "^23.2.0",
@@ -69,9 +70,7 @@
     "typescript": "^5.3.3",
     "vite": "^6.3.5",
     "vite-plugin-pwa": "^1.0.0",
-    "workbox-window": "^7.0.0",
-    "eslint-plugin-storybook": "9.0.12",
-    "@storybook/addon-docs": "^9.0.12"
+    "workbox-window": "^7.0.0"
   },
   "files": [
     "dist",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,4 @@
 @import './tokens.css';
-@import 'golden-layout/dist/css/goldenlayout-base.css';
-@import 'golden-layout/dist/css/themes/goldenlayout-light-theme.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- drop golden-layout dependency
- remove golden-layout styles
- update `EditorApp` to use a simple flex layout

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852fca9f4e08331a1dedf8d36a66ccd