### PR TITLE
Rename editor components to panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test Status](https://github.com/Tyler-R-Kendrick/open-editor-framework/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/Tyler-R-Kendrick/open-editor-framework/actions/workflows/test.yml)
 [![Lint Status](https://github.com/Tyler-R-Kendrick/open-editor-framework/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/Tyler-R-Kendrick/open-editor-framework/actions/workflows/lint.yml)
 
-A generic HTML5-based React editor built as a PWA (Progressive Web App) with comprehensive accessibility and mobile touch support. This framework provides a reusable canvas-based editor with component palette and property panel.
+A generic HTML5-based React editor built as a PWA (Progressive Web App) with comprehensive accessibility and mobile touch support. This framework provides a reusable canvas-based editor with component palette panel and property panel.
 
 ## ✨ Features
 
@@ -91,21 +91,21 @@ The editor is designed mobile-first with comprehensive touch gesture support:
 - Scalable fonts and UI elements
 - Clear focus indicators
 
-## 🎨 Component Architecture
+## 🎨 Panel Architecture
 
-### Core Components
+### Core Panels
 
 #### `editor-app`
-Main application component that orchestrates the canvas, palette, and control panel.
+Main application panel that orchestrates the canvas panel, palette panel, and control panel.
 
-#### `editor-canvas` 
-HTML5 canvas-based editor with touch support, zoom/pan, and component rendering.
+#### `editor-canvas`
+HTML5 canvas-based editor panel with touch support, zoom/pan, and component rendering.
 
 #### `component-palette`
-Drag-and-drop component library with search, categorization, and keyboard accessibility.
+Drag-and-drop component library panel with search, categorization, and keyboard accessibility.
 
 #### `control-panel`
-Dynamic property editor with type-specific controls for selected components.
+Dynamic property panel with type-specific controls for selected components.
 
 #### `editor-toolbar`
 Application toolbar with file operations, undo/redo, zoom controls, and theme toggle.

--- a/src/components/editor-app/README.md
+++ b/src/components/editor-app/README.md
@@ -1,6 +1,6 @@
-# EditorApp Component
+# EditorApp Panel
 
-A React-based main editor application component that orchestrates the canvas, palette, and control panel.
+A React-based main editor application panel that orchestrates the canvas panel, palette panel, and control panel.
 
 ## Features
 

--- a/src/components/editor-canvas/README.md
+++ b/src/components/editor-canvas/README.md
@@ -1,6 +1,6 @@
 # Editor Canvas
 
-An HTML5 Canvas-based editor component for rendering and manipulating components.
+An HTML5 Canvas-based editor panel for rendering and manipulating components.
 
 ## Features
 

--- a/src/components/editor-canvas/README_new.md
+++ b/src/components/editor-canvas/README_new.md
@@ -1,6 +1,6 @@
-# EditorCanvas Component
+# EditorCanvas Panel
 
-A React-based HTML5 Canvas editor component with touch and accessibility support.
+A React-based HTML5 Canvas editor panel with touch and accessibility support.
 
 ## Features
 

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -13,7 +13,7 @@ interface EditorCanvasProps {
 }
 
 /**
- * HTML5 Canvas-based editor component with touch and accessibility support
+ * HTML5 Canvas-based editor panel with touch and accessibility support
  * Features:
  * - Touch-optimized interactions (pan, zoom, tap, long press)
  * - Keyboard accessibility and shortcuts

--- a/src/components/editor-canvas/editor-canvas.stories.tsx
+++ b/src/components/editor-canvas/editor-canvas.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof EditorCanvas> = {
   parameters: {
     docs: {
       description: {
-        component: 'An HTML5 Canvas-based editor component for rendering and manipulating UI components. Supports touch interactions, keyboard shortcuts, and accessibility features.',
+        component: 'An HTML5 Canvas-based editor panel for rendering and manipulating UI components. Supports touch interactions, keyboard shortcuts, and accessibility features.',
       },
     },
   },


### PR DESCRIPTION
## Summary
- update docs to refer to panels instead of editor components
- tweak editor canvas docs and story descriptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852fcce20dc833198a180bcc85321e0