### PR TITLE
Integrate React Spectrum with i18n

### DIFF
--- a/__tests__/editor-app.test.tsx
+++ b/__tests__/editor-app.test.tsx
@@ -4,7 +4,10 @@ import { EditorApp } from '../src/components/editor-app/component';
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: async () => ({ templates: [], categories: [] }) })
+    Promise.resolve({
+      ok: true,
+      json: async () => ({ templates: [], categories: [] })
+    })
   ) as jest.Mock;
 });
 
@@ -12,8 +15,10 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-test('renders the main editor application', () => {
+test('renders the main editor application', async () => {
   render(<EditorApp />);
-  const app = screen.getByRole('application', { name: /react component editor/i });
+  const app = await screen.findByRole('application', {
+    name: /react component editor/i
+  });
   expect(app).toBeInTheDocument();
 });

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EditorToolbar } from '../src/components/toolbar/component';
+import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import { I18nProvider } from '@react-aria/i18n';
 
 test('renders toolbar', () => {
-  render(<EditorToolbar theme="light" onThemeChange={() => {}} />);
+  render(
+    <I18nProvider locale="en-US">
+      <Provider theme={defaultTheme} colorScheme="light">
+        <EditorToolbar theme="light" onThemeChange={() => {}} />
+      </Provider>
+    </I18nProvider>
+  );
   const toolbar = screen.getByRole('toolbar', { name: /editor toolbar/i });
   expect(toolbar).toBeInTheDocument();
 });

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '\\.(css|less|scss)$': 'identity-obj-proxy'
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts']
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -7,7 +7,9 @@ Object.defineProperty(window, 'matchMedia', {
     media: query,
     addEventListener: () => {},
     removeEventListener: () => {},
-  }),
+    addListener: () => {},
+    removeListener: () => {}
+  })
 });
 
 HTMLCanvasElement.prototype.getContext = () => null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@adobe/react-spectrum": "^3.42.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-stately/data": "^3.13.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -31,6 +34,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "9.0.12",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
         "jsdom": "^23.2.0",
@@ -52,6 +56,102 @@
       "integrity": "sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@adobe/react-spectrum": {
+      "version": "3.42.2",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.42.2.tgz",
+      "integrity": "sha512-6iLmVyEyBQhQuT5ZtT8q8Cpz1ZegZTod4DnhAu5J0ZjbSbQn+53NWGGTmHORJ7Qdmtd7h1wUeybMsuS8A7LYcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/collections": "3.0.0-rc.3",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-spectrum/accordion": "^3.0.8",
+        "@react-spectrum/actionbar": "^3.6.9",
+        "@react-spectrum/actiongroup": "^3.10.17",
+        "@react-spectrum/avatar": "^3.0.23",
+        "@react-spectrum/badge": "^3.1.25",
+        "@react-spectrum/breadcrumbs": "^3.9.19",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/buttongroup": "^3.6.23",
+        "@react-spectrum/calendar": "^3.7.3",
+        "@react-spectrum/checkbox": "^3.9.18",
+        "@react-spectrum/color": "^3.0.9",
+        "@react-spectrum/combobox": "^3.15.5",
+        "@react-spectrum/contextualhelp": "^3.6.23",
+        "@react-spectrum/datepicker": "^3.14.3",
+        "@react-spectrum/dialog": "^3.8.23",
+        "@react-spectrum/divider": "^3.5.24",
+        "@react-spectrum/dnd": "^3.5.7",
+        "@react-spectrum/dropzone": "^3.0.13",
+        "@react-spectrum/filetrigger": "^3.0.13",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/icon": "^3.8.6",
+        "@react-spectrum/illustratedmessage": "^3.5.11",
+        "@react-spectrum/image": "^3.5.12",
+        "@react-spectrum/inlinealert": "^3.2.17",
+        "@react-spectrum/labeledvalue": "^3.2.4",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/link": "^3.6.19",
+        "@react-spectrum/list": "^3.10.3",
+        "@react-spectrum/listbox": "^3.15.3",
+        "@react-spectrum/menu": "^3.22.3",
+        "@react-spectrum/meter": "^3.5.11",
+        "@react-spectrum/numberfield": "^3.9.15",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/picker": "^3.15.11",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/provider": "^3.10.7",
+        "@react-spectrum/radio": "^3.7.18",
+        "@react-spectrum/searchfield": "^3.8.18",
+        "@react-spectrum/slider": "^3.7.7",
+        "@react-spectrum/statuslight": "^3.5.23",
+        "@react-spectrum/switch": "^3.6.3",
+        "@react-spectrum/table": "^3.17.3",
+        "@react-spectrum/tabs": "^3.8.22",
+        "@react-spectrum/tag": "^3.3.2",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/textfield": "^3.13.5",
+        "@react-spectrum/theme-dark": "^3.5.19",
+        "@react-spectrum/theme-default": "^3.5.19",
+        "@react-spectrum/theme-light": "^3.4.19",
+        "@react-spectrum/toast": "^3.0.5",
+        "@react-spectrum/tooltip": "^3.7.7",
+        "@react-spectrum/tree": "^3.1.3",
+        "@react-spectrum/view": "^3.6.20",
+        "@react-spectrum/well": "^3.4.24",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/data": "^3.13.1",
+        "@react-types/shared": "^3.30.0",
+        "client-only": "^0.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@adobe/react-spectrum-ui": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum-ui/-/react-spectrum-ui-1.2.1.tgz",
+      "integrity": "sha512-wcrbEE2O/9WnEn6avBnaVRRx88S5PLFsPLr4wffzlbMfXeQsy+RMQwaJd3cbzrn18/j04Isit7f7Emfn0dhrJA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@adobe/react-spectrum-workflow": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum-workflow/-/react-spectrum-workflow-2.3.5.tgz",
+      "integrity": "sha512-b53VIPwPWKb/T5gzE3qs+QlGP5gVrw/LnWV3xMksDU+CRl3rzOKUwxIGiZO8ICyYh1WiyqY4myGlPU/nAynBUg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1878,7 +1978,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2741,6 +2840,57 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -2802,6 +2952,43 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
+      "integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.3.tgz",
+      "integrity": "sha512-p+Zh1sb6EfrfVaS86jlHGQ9HA66fJhV9x5LiE5vCbZtXEHAuhcmUZUdZ4WrFpUBfNalr2OkAJI5AcKEQF+Lebw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -3708,6 +3895,3311 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@react-aria/actiongroup": {
+      "version": "3.7.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/actiongroup/-/actiongroup-3.7.18.tgz",
+      "integrity": "sha512-dEF4CheaPn9PKtqyDpAwZ42u1LBSUiH0G72GoYE/Y9RTxI2ImABg+fxPGhF9z+ZxVNz2df8yyhBJFOtxwrBSqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/actiongroup": "^3.4.18",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/autocomplete": {
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-beta.5.tgz",
+      "integrity": "sha512-zYiVeKGYHStpBXS0mf51k14xkVunU/dFqxumfYXDiiyknxIDE4L1kN7XKo16nus3TkTmJtqBHJrWmzCfNkRd9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/combobox": "^3.12.5",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/searchfield": "^3.8.6",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/autocomplete": "3.0.0-beta.2",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-types/autocomplete": "3.0.0-alpha.32",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.26.tgz",
+      "integrity": "sha512-jybk2jy3m9KNmTpzJu87C0nkcMcGbZIyotgK1s8st8aUE2aJlxPZrvGuJTO8GUFZn9TKnCg3JjBC8qS9sizKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/link": "^3.8.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/breadcrumbs": "^3.7.14",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.13.3.tgz",
+      "integrity": "sha512-Xn7eTssaefNPUydogI1qDf7qQWPmb+hGoS1QiCNBodPlRpVDXxlZSIhOqQFnLWHv5+z5UL+vu+joqlSPYHqOFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/toolbar": "3.0.0-beta.18",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-1TAZADcWbfznXzo4oJEqFgX4IE1chZjWsTSJDWr03UEx3XqIJI8GXm+ylOQUiN4j8xqZ7tl4yNuuslKkzoSjMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/calendar": "^3.8.2",
+        "@react-types/button": "^3.12.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.15.7.tgz",
+      "integrity": "sha512-L64van+K2ZEmCpx/KeZGHoxdxQvVHgfusFRFYZbh3e7YEtDcShvUrTDVKmZkINqnmuhGTDolFDQq+E8fWEpcRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/toggle": "^3.11.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/checkbox": "^3.6.15",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/collections": {
+      "version": "3.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.0-rc.3.tgz",
+      "integrity": "sha512-TX6aAzK/FMTvT78LNdSSacKYDnfBWyW5WzxfoQiu/K/kbZVrYSrQaXFrGjkwGEhgmU0O1S4mupANMEgmgI3wlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/color": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.0.9.tgz",
+      "integrity": "sha512-dWyK8a3kNii8Yuj1/CQivnVVxsgkV8em+sb0oA29w04t+CFRQywpE2OVV3wZTDzOIVaz3pXx7/X012WoF6d/eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/numberfield": "^3.11.16",
+        "@react-aria/slider": "^3.7.21",
+        "@react-aria/spinbutton": "^3.6.16",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/color": "^3.8.6",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/color": "^3.0.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.12.5.tgz",
+      "integrity": "sha512-mg9RrOTjxQFPy0BQrlqdp5uUC2pLevIqhZit6OfndmOr7khQ32qepDjXoSwYeeSag/jrokc2cGfXfzOwrgAFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.14.5.tgz",
+      "integrity": "sha512-TeV/yXEOQ2QOYMxvetWcWUcZN83evmnmG/uSruTdk93e2nZzs227Gg/M95tzgCYRRACCzSzrGujJhNs12Nh7mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/number": "^3.6.3",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/spinbutton": "^3.6.16",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/datepicker": "^3.14.2",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/datepicker": "^3.12.2",
+        "@react-types/dialog": "^3.5.19",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.27.tgz",
+      "integrity": "sha512-Sp8LWQQYNxkLk2+L0bdWmAd9fz1YIrzvxbHXmAn9Tn6+/4SPnQhkOo+qQwtHFbjqe9fyS7cJZxegXd1RegIFew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/dialog": "^3.5.19",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/disclosure": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.0.6.tgz",
+      "integrity": "sha512-swO7U2G1Qhelj08RUiPQ8OEwDWDGj7DgWBmMyU2HjVEihR9wlvwsJTvzmxNQvJJT0l1bxQ/tM4RWxdUycUYy7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/disclosure": "^3.0.5",
+        "@react-types/button": "^3.12.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dnd": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.10.1.tgz",
+      "integrity": "sha512-EWiFbRoWs0zBlBbdPvd7gPyA3B8TPUtMfSUnLBCjwc+N0YaUoizZxW2VYgpAkZYAlVrPYV6n2Gs+98PHKZ8rsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/dnd": "^3.6.0",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.5.tgz",
+      "integrity": "sha512-JpFtXmWQ0Oca7FcvkqgjSyo6xEP7v3oQOLUId6o0xTvm4AD5W0mU2r3lYrbhsJ+XxdUUX4AVR5473sZZ85kU4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.0.18.tgz",
+      "integrity": "sha512-e4Ktc3NiNwV5dz82zVE7lspYmKwAnGoJfOHgc9MApS7Fy/BEAuVUuLgTjMo1x5me7dY+ADxqrIhbOpifscGGoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.2.tgz",
+      "integrity": "sha512-5oS6sLq0DishBvPVsWnxGcUdBRXyFXCj8/n02yJvjbID5Mpjn9JIHUSL4ZCZAO7QGCXpvO3PI40vB2F6QUs2VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/grid": "^3.11.3",
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/gridlist": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.13.2.tgz",
+      "integrity": "sha512-mPGhW2+Jke66LJIPrYoAdL5BBiC8iZ9orjoan7TBTCX9Xk87EK1XLm1cTxAylRqGNjnLzy+vp05Zt2fHY4QduA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/grid": "^3.14.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.10.tgz",
+      "integrity": "sha512-1j00soQ2W0nTgzaaIsGFdMF/5aN60AEdCJPhmXGZiuWdWzMxObN9LQ9vdzYPTjTqyqMdSaSp9DZKs5I26Xovpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.3",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.3.tgz",
+      "integrity": "sha512-J1bhlrNtjPS/fe5uJQ+0c7/jiXniwa4RQlP+Emjfc/iuqpW2RhbF9ou5vROcLzWIyaW8tVMZ468J68rAs/aZ5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.19",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.19.tgz",
+      "integrity": "sha512-ZJIj/BKf66q52idy24ErzX77vDGuyQn4neWtu51RRSk4npI3pJqEPsdkPCdo2dlBCo/Uc1pfuLGg2hY3N/ni9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.4.tgz",
+      "integrity": "sha512-1U5ce6cqg1qGbK4M4R6vwrhUrKXuUzReZwHaTrXxEY22IMxKDXIZL8G7pFpcKix2XKqjLZWf+g8ngGuNhtQ2QQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.3.tgz",
+      "integrity": "sha512-83gS9Bb+FMa4Tae2VQrOxWixqYhqj4MDt4Bn0i3gzsP/sPWr1bwo5DJmXfw16UAXMaccl1rUKSqqHdigqaealw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/link": "^3.6.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.14.6.tgz",
+      "integrity": "sha512-ZaYpBXiS+nUzxAmeCmXyvDcZECuZi1ZLn5y8uJ4ZFRVqSxqplVHodsQKwKqklmAM3+IVDyQx2WB4/HIKTGg2Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/listbox": "^3.7.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.3.tgz",
+      "integrity": "sha512-nbBmx30tW53Vlbq3BbMxHGbHa7vGE9ItacI+1XAdH2UZDLtdZA5J6U9YC6lokKQCv+aEVO6Zl9YG4yp57YwnGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.18.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.18.5.tgz",
+      "integrity": "sha512-mOQb4PcNvDdFhyqF7nxREwc1YUg+pPTiMNcSHlz/MKFkkUteIQBYfuJJa8i72ooiE55xfYEQhPLjmrLHAOIJ+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/menu": "^3.9.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/button": "^3.12.2",
+        "@react-types/menu": "^3.10.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/meter": {
+      "version": "3.4.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.24.tgz",
+      "integrity": "sha512-IYI0Z2pwMvIe8r/3G3PHhM4G/KRiW1ssFCBZdCjBbSpl6/EkmrHiyeaBYG0j8Ux8tmRmXiMVjxLdDlCJQDH7mQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.24",
+        "@react-types/meter": "^3.4.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.11.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.11.16.tgz",
+      "integrity": "sha512-AGk0BMdHXPP3gSy39UVropyvpNMxAElPGIcicjXXyD/tZdemsgLXUFT2zI4DwE0csFZS8BGgunLWT9VluMF4FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/spinbutton": "^3.6.16",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-types/button": "^3.12.2",
+        "@react-types/numberfield": "^3.8.12",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.27.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.3.tgz",
+      "integrity": "sha512-1hawsRI+QiM0TkPNwApNJ2+N49NQTP+48xq0JG8hdEUPChQLDoJ39cvT1sxdg0mnLDzLaAYkZrgfokq9sX6FLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/button": "^3.12.2",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.24",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.24.tgz",
+      "integrity": "sha512-lpMVrZlSo1Dulo67COCNrcRkJ+lRrC2PI3iRoOIlqw1Ljz4KFoSGyRudg/MLJ/YrQ+6zmNdz5ytdeThrZwHpPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/progress": "^3.5.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.11.5.tgz",
+      "integrity": "sha512-6BjpeTupQnxetfvC2bqIxWUt6USMqNZoKOoOO7mUL7ESF6/Gp8ocutvQn0VnTxU+7OhdrZX5AACPg/qIQYumVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/radio": "^3.10.14",
+        "@react-types/radio": "^3.8.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/searchfield": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.6.tgz",
+      "integrity": "sha512-fEhNOtOV5yRZ8hkWmFO5Mh8nq63/ePun2dUMLAiW1sCQXTUpN9Oo+T4vsEUabuZ25mHvqgVoCVhAFdMbvZ+W+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/searchfield": "^3.5.13",
+        "@react-types/button": "^3.12.2",
+        "@react-types/searchfield": "^3.6.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/select": {
+      "version": "3.15.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.15.7.tgz",
+      "integrity": "sha512-b1PpanLblnXgrvIeYPkL9ELdeE3GQXwoRJLNv9DSKSAyBVx+pm6+4BtzngOBdBidRCcOGEBEYxuUW8hMXjFB8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/select": "^3.6.14",
+        "@react-types/button": "^3.12.2",
+        "@react-types/select": "^3.9.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.24.3.tgz",
+      "integrity": "sha512-QznlHCUcjFgVALUIVBK4SWJd6osaU9lVaZgU4M8uemoIfOHqnBY3zThkQvEhcw/EJ2RpuYYLPOBYZBnk1knD5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/separator": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.10.tgz",
+      "integrity": "sha512-T9hJpO6lfg6zHRbs5CZD0eZrWIIjN6LY+EC6X5pQJbJeq6HqviVSQx25q98K430S/EGwHRltY5Bwy+XwlMZfdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.7.21",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.7.21.tgz",
+      "integrity": "sha512-eWu69KnQ7qCmpYBEkgGLjIuKfFqoHu2W6r9d7ys0ZmX81HPj9DhatGpEgHlnjRfCeSl9wL5h2FY9wnIio82cbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/slider": "^3.6.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.6.16.tgz",
+      "integrity": "sha512-Ko1e9GeQiiEXeR3IyPT8STS1Pw4k/1OBs9LqI3WKlHFwH5M8q3DbbaMOgekD41/CPVBKmCcqFM7K7Wu9kFrT2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.9.tgz",
+      "integrity": "sha512-2P5thfjfPy/np18e5wD4WPt8ydNXhij1jwA8oehxZTFqlgVMGXzcWKxTb4RtJrLFsqPO7RUQTiY8QJk0M4Vy2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.5.tgz",
+      "integrity": "sha512-GV9rFYf4wRHAh9tkhptvm3uOflKcQHdgZh+eGpSAHyq2iTq0j2nEhlmtFordpcJgC4XWro7TXLNltfqUqVHtkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.11.5",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/switch": "^3.5.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.5.tgz",
+      "integrity": "sha512-Q9HDr2EAhoah7HFIT6XxOOOv2fiAs0agwQQd3d1w6jqgyu9m20lM/jxcSwcCFj2O7FPKHfapSAijHDZZoc4Shg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/grid": "^3.14.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.14.3",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.10.5.tgz",
+      "integrity": "sha512-ddmGPikXW+27W2Rx0VuEwwGJVLTo68QkNbSl8R+TEM0EUIAJo3nwHzAlQhuo5Tcb1PdK7biTjO1dyI4pno2/0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/tabs": "^3.8.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tabs": "^3.3.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.6.2.tgz",
+      "integrity": "sha512-xO33FU0bZSpZ3Bw7bnJz7+Me0daVLJrn5dAllf18Mmf9T2cEr63Gg4AL4nR+rj6NLSq0aH8QyDtRGNqXJjo5SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.17.5.tgz",
+      "integrity": "sha512-HFdvqd3Mdp6WP7uYAWD64gRrL1D4Khi+Fm3dIHBhm1ANV0QjYkphJm4DYNDq/MXCZF46+CZNiOWEbL/aeviykA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/textfield": "^3.12.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.5.tgz",
+      "integrity": "sha512-uhwiZqPy6hqucBUL7z6uUZjAJ/ou3bNdTjZlXS+zbcm+T0dsjKDfzNkaebyZY7AX3cYkFCaRjc3N6omXwoAviw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/landmark": "^3.0.4",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/toast": "^3.1.1",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.11.5.tgz",
+      "integrity": "sha512-8+Evk/JVMQ25PNhbnHUvsAK99DAjnCWMdSBNswJ1sWseKCYQzBXsNkkF6Dl/FlSkfDBFAaRHkX9JUz02wehb9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.18.tgz",
+      "integrity": "sha512-P1fXhmTRBK4YvPQDzCY3XoZl+HiBADgvQ89jszxJ2jD4Qzs/E096ttCc+otZnbvRcoU27IxC2vWFInqK/bP31g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.5.tgz",
+      "integrity": "sha512-spGAuHHNkiqAfyOl4JWzKEK642KC1oQylioYg+LKCq2avUyaDqFlRx2JrC4a6nt3BV6E5/cJUMV9K7gMRApd5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/tooltip": "^3.5.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tooltip": "^3.4.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tree": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.1.tgz",
+      "integrity": "sha512-9LIe9unStA/9HHX6idHdbxMJLjebFP9mngIjoBgbWSNaYx3oH1X3Ei2Q9qHmimebtBagEZgSjxy7M+RcEqFhlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.29.1.tgz",
+      "integrity": "sha512-yXMFVJ73rbQ/yYE/49n5Uidjw7kh192WNN9PNQGV0Xoc7EJUlSOxqhnpHmYTyO0EotJ8fdM1fMH8durHjUSI8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.9",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/virtualizer": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.7.tgz",
+      "integrity": "sha512-mUJAWuLANVd6mXd7SKbGl9+LqrHxgkH/bo9qQTKaRKDWR3PVqU4m/xdY/u2EDGcWPiiTMHLJaPdMQA5OZ8LtMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.25.tgz",
+      "integrity": "sha512-9tRRFV1YMLuDId9E8PeUf0xy0KmQBoP8y/bm0PKWzXOqLOVmp/+kop9rwsjC7J6ppbBnlak7XCXTc7GoSFOCRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/accordion": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/accordion/-/accordion-3.0.8.tgz",
+      "integrity": "sha512-8U6fa7w1OJK7BTj4v8H4Kbu0FwbPwEkOumGCRwLvPR6mZz87fSthJf3MlER6Ewz4u8z99KoS2djzWajbMLSj8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/actionbar": {
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/actionbar/-/actionbar-3.6.9.tgz",
+      "integrity": "sha512-RNEbcqx4kO5qlDOlfe1mK+Uwg0j9GuiC4EaPrqy5IhwWHKmk1UKNHqP7RSVOdva1h1KdHsDyAmD5DM4RdKoQBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/actiongroup": "^3.10.17",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-types/actionbar": "^3.1.16",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/actiongroup": {
+      "version": "3.10.17",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/actiongroup/-/actiongroup-3.10.17.tgz",
+      "integrity": "sha512-ITIj930TU0R/38JrCGS/F4Zv+4yk0Ri9PimyeNWp80T4PI+1uj72VovAZhOr7wlfZT/7nvw7JvXXAIJH2j8jeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/actiongroup": "^3.7.18",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/menu": "^3.22.3",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/tooltip": "^3.7.7",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/actiongroup": "^3.4.18",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@spectrum-icons/workflow": "^4.2.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.2.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/avatar": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/avatar/-/avatar-3.0.23.tgz",
+      "integrity": "sha512-i1BuV/RS/D32vH/lI04e/TitmFpVnFqHQ+HzJcghnn9tK8umS7RV7vkgz3hTRFb27+oVzM8hcO6PfQfrVj33XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/avatar": "^3.0.16",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.2.1",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/badge": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/badge/-/badge-3.1.25.tgz",
+      "integrity": "sha512-QGKzgfOrRo3C8EE+drVF02DotlorU4S88Xqzc4ehRxqN2VPe93VbjUI95hnMWasNxBO4ix/xFbPNE54cVRNRdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/badge": "^3.1.18",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/breadcrumbs": {
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/breadcrumbs/-/breadcrumbs-3.9.19.tgz",
+      "integrity": "sha512-okG4hcn3H4mzcQjsoNLTUs2C9wQCR7h81DdJVJWq9aB/pgTMC1t68d8DXTBRqwlTJE09CVEIr7244Mu9n1u5ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/breadcrumbs": "^3.5.26",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/menu": "^3.22.3",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-types/breadcrumbs": "^3.7.14",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/button": {
+      "version": "3.16.16",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/button/-/button-3.16.16.tgz",
+      "integrity": "sha512-txnKlje7lH+Uz9hFlOL9e9cn6+ZKo/St62QBB7rbDQNLyy9K/cMTKn7jnXcs94BizPVbqmLnSONPLMC+S0oMcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/button": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/buttongroup": {
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/buttongroup/-/buttongroup-3.6.23.tgz",
+      "integrity": "sha512-OyjgbQTZ+w3TTNGiyavLIKfiaka4qbd9sQuHQQ3AjxezC6+XG4HCA/VUJww3EGGgKEYxG9GPBH+JKbwn8iHQMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/buttongroup": "^3.3.18",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/calendar": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/calendar/-/calendar-3.7.3.tgz",
+      "integrity": "sha512-X1fXse461yIrILIZH79XlsvGCKP/zxCkNF60b98IKhTLDWkDivRnG7UWQ9P4L/XC6mD5XcWQceJ6Kc+5rwe0ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-aria/calendar": "^3.8.3",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/calendar": "^3.8.2",
+        "@react-types/button": "^3.12.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/checkbox": {
+      "version": "3.9.18",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/checkbox/-/checkbox-3.9.18.tgz",
+      "integrity": "sha512-jb6jhRnFQHKYhQTHYOjG68W3NGgPPCu3kKdXPjS3bpYcbvAVlJ8HljF+i/ejiY9B2WOV/7zWrb+J9mX/lAj1yA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/checkbox": "^3.15.7",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/checkbox": "^3.6.15",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/color": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/color/-/color-3.0.9.tgz",
+      "integrity": "sha512-7CVuBO4whAgncXPlycOLWd5eG0EiPS4aRnktEveqGgSTvFQoVSfWt6rluxBPi2kNSA89YwnMRj1UPs9vfohw2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/color": "^3.0.9",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/dialog": "^3.8.23",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/picker": "^3.15.11",
+        "@react-spectrum/textfield": "^3.13.5",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-spectrum/view": "^3.6.20",
+        "@react-stately/color": "^3.8.6",
+        "@react-types/color": "^3.0.6",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/textfield": "^3.12.3",
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/combobox": {
+      "version": "3.15.5",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/combobox/-/combobox-3.15.5.tgz",
+      "integrity": "sha512-2bSnUTsczlKQW37bIdr715RI3tyL+zPjtxsowfa71nk2RVhR5gAgFoswO5RhtM1boEs+OPQjOxEikuTquQCk4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/combobox": "^3.12.5",
+        "@react-aria/dialog": "^3.5.27",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/form": "^3.0.18",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/listbox": "^3.15.3",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/textfield": "^3.13.5",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-types/button": "^3.12.2",
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/contextualhelp": {
+      "version": "3.6.23",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/contextualhelp/-/contextualhelp-3.6.23.tgz",
+      "integrity": "sha512-24JybTBDxvDE1LK6/zIPQV18NF6OMe01TwOqiom/T9xIYXmVLUwo5SK8Cu1NqRFP99SBzksxlzMmWH3VCt5l5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/dialog": "^3.8.23",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/contextualhelp": "^3.2.19",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/workflow": "^4.2.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/datepicker": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/datepicker/-/datepicker-3.14.3.tgz",
+      "integrity": "sha512-Siqv/kMVNY/qZLDqXYGJSEdCC682+x7anijylJxzACNO5uFWnxbV4mJsdurQNLDKVezHM7ip+qvxzfseLrF84Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-aria/datepicker": "^3.14.5",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/calendar": "^3.7.3",
+        "@react-spectrum/dialog": "^3.8.23",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-spectrum/view": "^3.6.20",
+        "@react-stately/datepicker": "^3.14.2",
+        "@react-types/datepicker": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@spectrum-icons/workflow": "^4.2.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/dialog": {
+      "version": "3.8.23",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dialog/-/dialog-3.8.23.tgz",
+      "integrity": "sha512-fxh5fY+SpPi9Ee0gTKveUsnXk+V2qLg1GIOcycjbsnFLClgx0EScq0bhjZew19B+cI+xDepXLigGrF/bDcBY1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/dialog": "^3.5.27",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/buttongroup": "^3.6.23",
+        "@react-spectrum/divider": "^3.5.24",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-spectrum/view": "^3.6.20",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/button": "^3.12.2",
+        "@react-types/dialog": "^3.5.19",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/divider": {
+      "version": "3.5.24",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/divider/-/divider-3.5.24.tgz",
+      "integrity": "sha512-qlkButgrc/lRPE7+fmi3oY+jXCeWRFYcR2yIlmdA1coeQ6jCK2ipSCnWmcKm2hXX3CFnZhCd9dED85DM70v0Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/separator": "^3.4.10",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/divider": "^3.3.18",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/dnd": {
+      "version": "3.5.7",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dnd/-/dnd-3.5.7.tgz",
+      "integrity": "sha512-X+0iiLEo95xxhl1Qq5WzZHTN2+QjLtF+N+TGtZR28IytjAMy9YPEeuOXZLtodikL+jqnAMNq/GZfBtqPTXwL+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/dnd": "^3.10.1",
+        "@react-stately/dnd": "^3.6.0",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/dropzone": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/dropzone/-/dropzone-3.0.13.tgz",
+      "integrity": "sha512-cvIpmtOGr197bRQwaBWH2Y91CAoif76Erb7w0gQFolIcq8kZyLa4Zb/9VrqSGD2xL24tyI73KGvl3ayzUAP5KA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/filetrigger": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/filetrigger/-/filetrigger-3.0.13.tgz",
+      "integrity": "sha512-YGPulb7FJZganJa9Ki+woC/OPJxT7cE2T3mTlpUwqq/erWQ+q9+SOr/XmIEEaS2qgK4Vu3ImI+OAaJ367T2mLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/form": {
+      "version": "3.7.16",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/form/-/form-3.7.16.tgz",
+      "integrity": "sha512-wPZrrBImtPeiGUH/ZC8X0+0shXrG2uSltjq3ojOV2r0OU4qFLy2DJEWGVb26ToNqmXNcEG6fRtuAAfPRCNOAxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/form": "^3.1.5",
+        "@react-types/form": "^3.7.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/icon": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/icon/-/icon-3.8.6.tgz",
+      "integrity": "sha512-b4jMBYm3s5wLN5ew4iVQhec/BDv2ZEas394Udk1HkrQb96FkUeb2iYTzsSpIB2hIYnCUIHsZFcXWRG3lBtI/sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/illustratedmessage": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/illustratedmessage/-/illustratedmessage-3.5.11.tgz",
+      "integrity": "sha512-UwG9xZ93x5eUcPzOAYZw39b7IO+z57ZxuF41AFlsKYfUet6rc8WaI6TLWVW+TLkoDR1aqnB3fXYkSmKWZ3Od4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/illustratedmessage": "^3.3.18",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/image": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/image/-/image-3.5.12.tgz",
+      "integrity": "sha512-tJ955yEkbzDkVympPYMh06PcYXQV13mcQnrklYWON67ZuaERTLfiPprTX2gjMxbh3hnX7kvMQy8a/q9SkhNbfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/image": "^3.4.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/inlinealert": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/inlinealert/-/inlinealert-3.2.17.tgz",
+      "integrity": "sha512-jUsWs7GTGj1Zm6ZfgtdO9JJ4ArckqFas/vpv5Amy+iUt55GUkviblTwydzREXpc5wq2crgIfhHlZlXM38Ad00A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/label": {
+      "version": "3.16.16",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/label/-/label-3.16.16.tgz",
+      "integrity": "sha512-UmA6pbL+Bxq0sYHy1y7o711dth3aRAgBMfHV5R3NN7qB5EwEYbl3n40cNu8dC0CMKQ1BIEFQRtVqUU9TVR5FUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/label": "^3.9.12",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/labeledvalue": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/labeledvalue/-/labeledvalue-3.2.4.tgz",
+      "integrity": "sha512-vGhqQGlbE8pys7zsqj83LaTcMx5+YIdkJFK/Qdc1how3jo0w3P8u45dC4Ei0icVW3+y6453bHGUi6+NJV89fzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/layout": {
+      "version": "3.6.16",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/layout/-/layout-3.6.16.tgz",
+      "integrity": "sha512-BRG0vVssIxtkyOiFAjVVuJvG1/sAMB1nUeIJF0G/xjtMyLAJVSHjAizlwsLE5iWj6XiuEIG6yUIkDCNzUJp+xQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/layout": "^3.3.24",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/link": {
+      "version": "3.6.19",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/link/-/link-3.6.19.tgz",
+      "integrity": "sha512-ySBW8ckURYDm2Eqat+jKFkQ1o0TDum1KcxP77UV6oLgmnfJf3PO0WvOg7JgKRPZM2jk3IJADScX2J+Q2ZgW8sQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/link": "^3.8.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/link": "^3.6.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/list": {
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/list/-/list-3.10.3.tgz",
+      "integrity": "sha512-pfr8aOpCiF55Rtt4W9NicyuDzTodJCXVfsOZ6DiwCsn+vPjBJMTHrWxXj1OcwNdRthvJLI+p2FsOHsxJXdNexw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/virtualizer": "^4.1.7",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-spectrum/checkbox": "^3.9.18",
+        "@react-spectrum/dnd": "^3.5.7",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/layout": "^4.3.1",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.2.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/listbox": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/listbox/-/listbox-3.15.3.tgz",
+      "integrity": "sha512-pEMJxgAwEO/OUmlCVALwYLSuDQTDtepY77Xm7JEWHOKH+Qh+7WfG7JHkNbe95p2uyjBjbmB00SYYhaAGYVx9Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/virtualizer": "^4.1.7",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/layout": "^4.3.1",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/listbox": "^3.7.1",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.2.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/menu": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/menu/-/menu-3.22.3.tgz",
+      "integrity": "sha512-RCX4i6ocVtt+Zs11c9IRpk4pF3BkZykgBfVHyDb0pUEjzLjNB23bHUMApEuuohjaxz6d2w9Lx04E14ccfQ06aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/separator": "^3.4.10",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/menu": "^3.9.5",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/menu": "^3.10.2",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@spectrum-icons/workflow": "^4.2.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/meter": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/meter/-/meter-3.5.11.tgz",
+      "integrity": "sha512-F3fcNICWel5jVyc9q2m2EPu7ICA1zLvRbrZTnOZY/VcNjEfd2pGPe5AJUBm9gFOkx5oCDTYsVok7dEO3h5oDyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/meter": "^3.4.24",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/meter": "^3.4.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/numberfield": {
+      "version": "3.9.15",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/numberfield/-/numberfield-3.9.15.tgz",
+      "integrity": "sha512-PwedLxYDAIbfxDzoOsoZfIqqakcWH7kB+V7lBQ6pA+U04u+ZAyX0pMCWa505t7hAeS6YINt/Kd05sXE34uNjuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/numberfield": "^3.11.16",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/textfield": "^3.13.5",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-types/button": "^3.12.2",
+        "@react-types/numberfield": "^3.8.12",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@spectrum-icons/workflow": "^4.2.22",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/overlays": {
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/overlays/-/overlays-5.7.7.tgz",
+      "integrity": "sha512-AZz4V1iMcT14qzYYwhUipaZTYPeHu/bfBqU0E0gnhLtpZmpKg3Q8j3TLllqrBmUT4G3bpmXvbZB7KR7E+f6Hdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/picker": {
+      "version": "3.15.11",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/picker/-/picker-3.15.11.tgz",
+      "integrity": "sha512-yuco56SE/fpuDBBFlVisDf4d990oKELdSsi8oieCEIeKMxrh2Sxs3QiUbVolVKORrt86oFXysaPhmXAS+8uG9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/select": "^3.15.7",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/listbox": "^3.15.3",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/select": "^3.6.14",
+        "@react-types/select": "^3.9.13",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.1.4",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/progress": {
+      "version": "3.7.17",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/progress/-/progress-3.7.17.tgz",
+      "integrity": "sha512-lxbFn87P2QcEuxD+aY6rJlDm1kPeDOIRRy+DC9joS+gjpH4O9L3po+CoFRK+sf6aBgXhRQKi/eU5gZ0B99g0Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.24",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/progress": "^3.5.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/provider": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/provider/-/provider-3.10.7.tgz",
+      "integrity": "sha512-TCEj+uVcdKIzzcYuYg/OCkx3i1Rc3YCYIipTgRge574b1l7U53tijdTha6wA7jA66V8hErJGIc7Ihy6BRxWJqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/provider": "^3.8.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/radio": {
+      "version": "3.7.18",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/radio/-/radio-3.7.18.tgz",
+      "integrity": "sha512-BSnmC9Pc5MtrSplzRcx0lmX+CKzDCe2yZH1Gs4Zk7u38ZMbB6g0NrpaQ8UcV7Ux9w0Kn9Tj1Dmo1ecrk2OuSMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/radio": "^3.11.5",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/radio": "^3.10.14",
+        "@react-types/radio": "^3.8.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/searchfield": {
+      "version": "3.8.18",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/searchfield/-/searchfield-3.8.18.tgz",
+      "integrity": "sha512-SGdYdCk08O9o5AbA/TkoPywFrhqPm3ou7DGGh0eKGlBMLrFhEC7OYcYJMazO25tYOlKf7Wu61KA5s1rEJNWQog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/searchfield": "^3.8.6",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/textfield": "^3.13.5",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/searchfield": "^3.5.13",
+        "@react-types/searchfield": "^3.6.3",
+        "@react-types/textfield": "^3.12.3",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/slider": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/slider/-/slider-3.7.7.tgz",
+      "integrity": "sha512-GktV8VTdyCqhP7j+fe9nLqtaIRjV+HTP3jbMdbFicnM6DYLvtgIV6hS9jSkMxG5BMQg36QYrSDUcURMm/mXMZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/slider": "^3.7.21",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/slider": "^3.6.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/statuslight": {
+      "version": "3.5.23",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/statuslight/-/statuslight-3.5.23.tgz",
+      "integrity": "sha512-RdzjNcu552CHFRNfPQcdiOhoRujMGiMZdYvLr2WhIJ6aRIWcNCMPZgYOvV+EQBy2krngz60qDLFp41vwRPxtHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/statuslight": "^3.3.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/switch": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/switch/-/switch-3.6.3.tgz",
+      "integrity": "sha512-//JrYHfvrDXEBNaQKcNWK7SmEEa3i7mUFoo1CKJAhmev+FBjM44R+cUUKF37QdS1IDkkwEtyyKnqfOWqN0vGlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/switch": "^3.7.5",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/switch": "^3.5.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/table": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/table/-/table-3.17.3.tgz",
+      "integrity": "sha512-sl4x9PT5PmmK+aDoeh73VmU2REgHM6eFzfUmtQMvNlN/Kz49MQwzQzYpzT9ZBwn5Mzu/CxYOk/tTID37bim8ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/table": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/virtualizer": "^4.1.7",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-spectrum/checkbox": "^3.9.18",
+        "@react-spectrum/dnd": "^3.5.7",
+        "@react-spectrum/layout": "^3.6.16",
+        "@react-spectrum/menu": "^3.22.3",
+        "@react-spectrum/progress": "^3.7.17",
+        "@react-spectrum/tooltip": "^3.7.7",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/layout": "^4.3.1",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/tabs": {
+      "version": "3.8.22",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tabs/-/tabs-3.8.22.tgz",
+      "integrity": "sha512-F3wNaTzlEdxc5A6+JRIAJdNObLG1p5KVGUH83SUHOhidi0p0WTlqwtIIOEXx/jr7a2Y56eN3JoMcT6K9PlkUjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/tabs": "^3.10.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/picker": "^3.15.11",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/tabs": "^3.8.3",
+        "@react-types/select": "^3.9.13",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tabs": "^3.3.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/tag": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tag/-/tag-3.3.2.tgz",
+      "integrity": "sha512-qhh6PRw2aq6tqAZCoKTROOYM3JDhs5DEhG2LKxYFv95nF+xRF4ty3VRecrALcU1wfRUv2cwwb5FrMHC3oC7nVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/tag": "^3.6.2",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/text": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/text/-/text-3.5.17.tgz",
+      "integrity": "sha512-tfPHparrk7OekGd5UFCpWSMifvZK1D/jcoIHcSvThNnx6tQlLSGmvMWiFpq5L1AC+hqcPOue4t9jQOXFOr/WKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/text": "^3.3.18",
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/textfield": {
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/textfield/-/textfield-3.13.5.tgz",
+      "integrity": "sha512-NVaYwIBvXnLx+HObNGNviAj4NqEUQhxMCw+rqv9dubQezn2wwh7pgYbkdQwU9SggjaeRBbADQXW4YSvdbRnCLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/form": "^3.7.16",
+        "@react-spectrum/label": "^3.16.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/textfield": "^3.12.3",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/theme-dark": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/theme-dark/-/theme-dark-3.5.19.tgz",
+      "integrity": "sha512-m8B8JxxtuZM+a+SIK3uPKRgH0tuPcn/ucMN8nDLSRiJ/5npiThb++UIlDV4af4Rkxf4CrFzP8xIwOZ1xk4SprA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/provider": "^3.8.10",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/theme-default": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/theme-default/-/theme-default-3.5.19.tgz",
+      "integrity": "sha512-cJit+6HnYsdD65sYmdDYlpqW2TsVNXsZSQtDnbvx/jTiNuqr2p/NJiaoQmV/qsmzFhOZNjaTMB57f0S5mLHR+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/provider": "^3.8.10",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/theme-light": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/theme-light/-/theme-light-3.4.19.tgz",
+      "integrity": "sha512-0Oq9QrqAPyFZEi/SXlOnSAZOvwBUvAaJrRZCmx2CMxpOIwHg/dOCNazD4xikTCnzjN2TOeAAahMtEp7dxHa77Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/provider": "^3.8.10",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/toast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/toast/-/toast-3.0.5.tgz",
+      "integrity": "sha512-eqTA356iCF0NMeyZZJbGV4mVxNvBHgdQjL98dKMUWBQaa67+F5a7dv4wjD+w7txhagBOugqbkhO2hcOCH3GI1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/toast": "^3.0.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/button": "^3.16.16",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/toast": "^3.1.1",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/tooltip": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tooltip/-/tooltip-3.7.7.tgz",
+      "integrity": "sha512-Ch+lSZjRlTSygTYcGHslR/Qpw2WjSww4VaKf6UdXE3LaNTcEl7UUzEWbyU0OmzyKpnywV80dV7ZK7yPB9msIWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/tooltip": "^3.8.5",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/overlays": "^5.7.7",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-stately/tooltip": "^3.5.5",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tooltip": "^3.4.18",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/tree": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/tree/-/tree-3.1.3.tgz",
+      "integrity": "sha512-AIq1sOqs6/mx10UQlkJgfnxGYTritNxqPrs0UuzvHSJFjfi/irTjK2BJdN7cgJSAx3w8vw9NGaPt7F9fTTLj5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/tree": "^3.1.1",
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/checkbox": "^3.9.18",
+        "@react-spectrum/text": "^3.5.17",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@spectrum-icons/ui": "^3.6.17",
+        "@swc/helpers": "^0.5.0",
+        "react-aria-components": "^1.10.1"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/utils": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/utils/-/utils-3.12.6.tgz",
+      "integrity": "sha512-9Ry6O8thFAEd/vDd05sx/7PMmv/FuiTlcxDzexsr9022Fqtq0IF1qwNFZYJxkhEBgptsx+/92fvj1YCvuumxOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/view": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/view/-/view-3.6.20.tgz",
+      "integrity": "sha512-1Fm1k0M6mxjshes61vShgESi/iMd88wG/Em8bj0xRBYqmMTwybMtp5Zy2d+6JL8HRCIH46JptLEWWaYFYdC/tw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/view": "^3.4.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-spectrum/well": {
+      "version": "3.4.24",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/well/-/well-3.4.24.tgz",
+      "integrity": "sha512-F1ElFwVWU6DnJEzIjoFpEax2eVpt63vwfEUUXn3Ake80v+Egt881PX7LdD4TSQk2+MA3MFWDuMIagVG7pYtbbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-spectrum/utils": "^3.12.6",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/well": "^3.3.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/autocomplete": {
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.2.tgz",
+      "integrity": "sha512-6I9vFwRmoxnx5MWA5FCflH6PNjY4+bjE7+sUrFHuDf8BhkwGYtQkRGA45P3KR2gK1dECskG1qqw36lqop4zcaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.8.2.tgz",
+      "integrity": "sha512-IGSbTgCMiGYisQ+CwH31wek10UWvNZ1LVwhr0ZNkhDIRtj+p+FuLNtBnmT1CxTFe2Y4empAxyxNA0QSjQrOtvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.15.tgz",
+      "integrity": "sha512-jt3Kzbk6heUMtAlCbUwnrEBknnzFhPBFMEZ00vff7VyhDXup7DJcJRxreloHepARZLIhLhC5QPyO5GS4YOHlvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.5.tgz",
+      "integrity": "sha512-5SIb+6nF9cyu+WXqZ6io56BtdOu8FjSQQaaLCCpfAC6fc6zHRk8by0WreRmvJ5/Kn8oq2FNJtCNRvluM0Z01UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/color": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.8.6.tgz",
+      "integrity": "sha512-KBpnXt31hCgdYq1a7PxUspK990/V5hPO4LqJ1K89p7r2t4OF66IBW5FmOS7KY6p1bGOoZgbk9m5w+yUeQq4wmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.3",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-stately/slider": "^3.6.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/color": "^3.0.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.10.6.tgz",
+      "integrity": "sha512-XOfG90MQPfPCNjl2KJOKuFFzx2ULlwnJ/QXl9zCQUtUBOExbFRHldj5E4NPcH14AVeYZX6DBn4GTS9ocOVbE7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/select": "^3.6.14",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/data": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.13.1.tgz",
+      "integrity": "sha512-hKEvHCM/nHM6FFJz3gT6Ms85H+qNhXfHDYP/TU7XiDoeVHzUpj2Yc3xGsIty6/K2k7jrblUj+LuKmdvidd9mug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.14.2.tgz",
+      "integrity": "sha512-KvOUFz/o+hNIb7oCli6nxBdDurbGjRjye6U99GEYAx6timXOjiIJvtKQyqCLRowGYtCS6GH41yM6DhJ2MlMF8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/datepicker": "^3.12.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/disclosure": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.5.tgz",
+      "integrity": "sha512-Rh+y+XAUNwyFvvzBS/MtFvdWHC38mXI99S6mdNe3e5Og8IZxLBDtvwBCzrT30YzYqN40yd3alm9xLzpYXsvYYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/dnd": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.6.0.tgz",
+      "integrity": "sha512-H0zWOjjoocM+8r5rJ2x0B66NXZd2+7lF1zhomoMoR5+57DA5hWZTY0tht21DKjNoFk4f96Ythh0jRLziQbSkBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.1.5.tgz",
+      "integrity": "sha512-wOs0SVXFgNr1aIdywiNH1MhxrFlN5YxBr1k9y3Z7lX+pc/MGRJFTgfDDw5JDxvwLH9joJ9ciniCdWep9L/TqcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.3.tgz",
+      "integrity": "sha512-/YurYfPARtgsgS5f8rklB7ZQu6MWLdpfTHuwOELEUZ4L52S2gGA5VfLxDnAsHHnu5XHFI3ScuYLAvjWN0rgs/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/layout": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.3.1.tgz",
+      "integrity": "sha512-W2aa60I3qCI24HzZaFsS/eV1aCL0YI3IOlYm9PgsbELP82y3n7YRnwVreUv30KVdpn0VviLZn2xdWSeZlyqi9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.12.3.tgz",
+      "integrity": "sha512-RiqYyxPYAF3YRBEin8/WHC8/hvpZ/fG1Tx3h1W4aXU5zTIBuy0DrjRKePwP90oCiDpztgRXePLlzhgWeKvJEow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.5.tgz",
+      "integrity": "sha512-Y+PqHBaQToo6ooCB4i4RoNfRiHbd4iozmLWePBrF4d/zBzJ9p+/5O6XIWFxLw4O128Tg3tSMGuwrxfecPDYHzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/menu": "^3.10.2",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.9.13",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.9.13.tgz",
+      "integrity": "sha512-FWbbL4E3+5uctPGVtDwHzeNXgyFw0D3glOJhgW1QHPn3qIswusn0z/NjFSuCVOSpri8BZYIrTPUQHpRJPnjgRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.3",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/numberfield": "^3.8.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.17.tgz",
+      "integrity": "sha512-bkGYU4NPC/LgX9OGHLG8hpf9QDoazlb6fKfD+b5o7GtOdctBqCR287T/IBOQyvHqpySqrQ8XlyaGxJPGIcCiZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/overlays": "^3.8.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.10.14",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.10.14.tgz",
+      "integrity": "sha512-Y7xizUWJ0YJ8pEtqMeKOibX21B5dk56fHgMHXYLeUEm43y5muWQft2YvP0/n4mlkP2Isbk96kPbv7/ez3Gi+lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/radio": "^3.8.10",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/searchfield": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.13.tgz",
+      "integrity": "sha512-JNvsnvK6A1057hQREHabRYAAtwj2vl20oqGBvl1IleKlFe3KInV9WBY5l6zR3RXrnCPHVvJuzGe2R7+g142Mnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/searchfield": "^3.6.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.6.14.tgz",
+      "integrity": "sha512-HvbL9iMGwbev0FR6PzivhjKEcXADgcJC/IzUkLqPfg4KKMuYhM/XvbJjWXn/QpD3/XT+A5+r5ExUHu7wiDP93w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/select": "^3.9.13",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.3.tgz",
+      "integrity": "sha512-TLyjodgFHn5fynQnRmZ5YX1HRY0KC7XBW0Nf2+q9mWk4gUxYm7RVXyYZvMIG1iKqinPYtySPRHdNzyXq9P9sxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.6.5.tgz",
+      "integrity": "sha512-XnHSHbXeHiE5J7nsXQvlXaKaNn1Z4jO1aQyiZsolK1NXW6VMKVeAgZUBG45k7xQW06aRbjREMmiIz02mW8fajQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.14.3.tgz",
+      "integrity": "sha512-PwE5pCplLSDckvgmNLVaHyQyX04A62kxdouFh1dVHeGEPfOYsO9WhvyisLxbH7X8Dbveheq/tSTelYDi6LXEJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.3",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.3.tgz",
+      "integrity": "sha512-FujQCHppXyeHs2v5FESekxodsBJ5T0k1f7sm0ViNYqgrnE5XwqX8Y4/tdr0fqGF6S+BBllH+Q9yKWipDc6OM8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.12.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/tabs": "^3.3.16",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.1.tgz",
+      "integrity": "sha512-W4a6xcsFt/E+aHmR2eZK+/p7Y5rdyXSCQ5gKSnbck+S3lijEWAyV45Mv8v95CQqu0bQijj6sy2Js1szq10HVwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.8.5.tgz",
+      "integrity": "sha512-BSvuTDVFzIKxpNg9Slf+RdGpva7kBO8xYaec2TW9m6Ag9AOmiDwUzzDAO0DRsc7ArSaLLFaQ/pdmmT6TxAUQIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/checkbox": "^3.9.5",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.5.tgz",
+      "integrity": "sha512-/zbl7YxneGDGGzdMPSEYUKsnVRGgvsr80ZjQYBHL82N4tzvtkRwmzvzN9ipAtza+0jmeftt3N+YSyxvizVbeKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.17",
+        "@react-types/tooltip": "^3.4.18",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.0.tgz",
+      "integrity": "sha512-VpWAh36tbMHJ1CtglPQ81KPdpCfqFz9yAC6nQuL1x6Tmbs9vNEKloGILMI9/4qLzC+3nhCVJj6hN+xqS5/cMTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.7.tgz",
+      "integrity": "sha512-cWvjGAocvy4abO9zbr6PW6taHgF24Mwy/LbQ4TC4Aq3tKdKDntxyD+sh7AkSRfJRT2ccMVaHVv2+FfHThd3PKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.1.tgz",
+      "integrity": "sha512-ZjhsmsNqKY4HrTuT9ySh8lNmYHGgFX24CVVQ3hMr8dTzO9DRR89BMrmenoVtMj7NkonWF8lUFyYlVlsijs2p4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.29.1",
+        "@react-types/shared": "^3.30.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/actionbar": {
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/@react-types/actionbar/-/actionbar-3.1.16.tgz",
+      "integrity": "sha512-ZdT8gqLZa2kRemBtwoXdj/RT9RO1zb5EXJCy43rtlZzMBD+gDhPUMDdJidXp29HTABhnxST1sg8d1e5g8MkfVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/actiongroup": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/@react-types/actiongroup/-/actiongroup-3.4.18.tgz",
+      "integrity": "sha512-9CXxhOPwXVQ1r84Weu/4qPSoMguFRmilC0Pvf1StoZAYgB+azNgJvlRrhk+MB+keRSMXdC6noy+Kh5ZnO+3tKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/autocomplete": {
+      "version": "3.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.32.tgz",
+      "integrity": "sha512-eRi5n+QMMI3IUMX8z2+dnbQXaTgEgsmp2Qg1a/6HobJzq3IviIjkrG1B4jwp+kZHca7OuVa2ouiWvBu9sW9o4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/combobox": "^3.13.6",
+        "@react-types/searchfield": "^3.6.3",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/avatar": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@react-types/avatar/-/avatar-3.0.16.tgz",
+      "integrity": "sha512-7woldQQ8Mjv9EtE9dwnQqLuxLCAFpIiV/riBOD6r5qyb0+PMB3SMj3NjSR5mph5TzTfXFrnHYaoEysIg/7ut6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/badge": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/@react-types/badge/-/badge-3.1.18.tgz",
+      "integrity": "sha512-HqqS9OoDpAcTVLd4s5C67OONfRwDqIORrKdvRVOiUSEvEoV2blcmGBGyV79Wnc5V0kop6SHCg5yDlEi5uxmlXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.14",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.14.tgz",
+      "integrity": "sha512-SbLjrKKupzCLbqHZIQYtQvtsXN53NPxOYyug6QfC4d7DcW1Q9wJ546fxb10Y83ftAJMMUHTatI6SenJVoqyUdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.2",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.2.tgz",
+      "integrity": "sha512-QLoSCX8E7NFIdkVMa65TPieve0rKeltfcIxiMtrphjfNn+83L0IHMcbhjf4r4W19c/zqGbw3E53Hx8mNukoTUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/buttongroup": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/buttongroup/-/buttongroup-3.3.18.tgz",
+      "integrity": "sha512-bgFjOwa+Ufog/6mFJWXciKgF86iDamlETfa3iIDLBN2IK4MXfacpTai/61nPc2bXggz24JRBniPCJfHmr5Kt7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.7.2.tgz",
+      "integrity": "sha512-Bp6fZo52fZdUjYbtJXcaLQ0jWEOeSoyZVwNyN5G6BmPyLP5nHxMPF+R1MPFR0fdpSI4/Sk78gWzoTuU5eOVQLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.9.5.tgz",
+      "integrity": "sha512-9y8zeGWT2xZ38/YC/rNd05pPV8W8vmqFygCpZFaa6dJeOsMgPU+rq+Ifh1G+34D/qGoZXQBzeCSCAKSNPaL7uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/color": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.0.6.tgz",
+      "integrity": "sha512-ZbbgzAWK56RMMZzRGhTAB9Fz9PGnj6ctc6VMqOyumCOF9NKkYgI0E2ssTY/iOXBazZvhhhGahbGl+kjmgWvS6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@react-types/slider": "^3.7.12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.6.tgz",
+      "integrity": "sha512-BOvlyoVtmQJLYtNt4w6RvRORqK4eawW48CcQIR93BU5YFcAGhpcvpjhTZXknSXumabpo1/XQKX4NOuXpfUZrAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/contextualhelp": {
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/@react-types/contextualhelp/-/contextualhelp-3.2.19.tgz",
+      "integrity": "sha512-csrQKdhY6PKBgpaRSa94abVGKVA3sSqU+rPjZMx4mXrGXiK0C6Jlox4FW8Rz6/JqATB8PFaxTK9JwJ1H11iCnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.12.2.tgz",
+      "integrity": "sha512-w3JIXZLLZ15zjrAjlnflmCXkNDmIelcaChhmslTVWCf0lUpgu1cUC4WAaS71rOgU03SCcrtQ0K9TsYfhnhhL7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-types/calendar": "^3.7.2",
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.19.tgz",
+      "integrity": "sha512-+FIyFnoKIGNL20zG8Sye7rrRxmt5HoeaCaHhDCTtNtv8CZEhm3Z+kNd4gylgWAxZRhDtBRWko+ADqfN5gQrgKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/divider": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/divider/-/divider-3.3.18.tgz",
+      "integrity": "sha512-3pr530PVApZIzPYZEio/AAIsBp9o1agRMG2XyKWQ6DRLhHWxOTsasBZbHBNElh31v5Q0pO2llhUeDY0OuO+PqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.13",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.13.tgz",
+      "integrity": "sha512-Ryw9QDLpHi0xsNe+eucgpADeaRSmsd7+SBsL15soEXJ50K/EoPtQOkm6fE4lhfqAX8or12UF9FBcBLULmfCVNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.3.tgz",
+      "integrity": "sha512-VZAKO3XISc/3+a+DZ+hUx2NB/buOe2Ui2nISutv25foeXX4+YpWj5lXS74lJUCuVsSz6D6yoWvEajeUCYrNOxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/illustratedmessage": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/illustratedmessage/-/illustratedmessage-3.3.18.tgz",
+      "integrity": "sha512-D8PmsszVAz9KQ90/j6R7Q55gKdm1cORrr9aae8QUFT+XUZSkZm7sW1+jwqsrkfibyHixKX2Ut8tNV++WUR4dzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/image": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@react-types/image/-/image-3.4.10.tgz",
+      "integrity": "sha512-iDAAD1ruvNCn7sCIi6T0W4A8lq+p0khBdOuMLrAZPBfPPXFRbHkp4RvHVvuy4N45GVlaCn2yxT/QoCv1zEYcgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/label": {
+      "version": "3.9.12",
+      "resolved": "https://registry.npmjs.org/@react-types/label/-/label-3.9.12.tgz",
+      "integrity": "sha512-l1UwZIx8kzu3aVxh/b9xLk+WzzzWefMBH/9FfXNxEnhW/Gin7N7SJS8vJqs6QjBjAADJ+kGBGLUv5g/wMzEDTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/layout": {
+      "version": "3.3.24",
+      "resolved": "https://registry.npmjs.org/@react-types/layout/-/layout-3.3.24.tgz",
+      "integrity": "sha512-CE9zGLUTu7JW6iYsnMNB0SidgOqg3GqXCPPlsUKoxmnVU9vxlpGIvTiHESm6302CA47RxrU80DIQLXnjZSWCGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.2.tgz",
+      "integrity": "sha512-CtCexoupcaFHJdVPRUpJ83uxK1U0bd9x9DhwRFMqqfPHufICkQkETIw2KIeZXRvMUMi2CSG/81XXy6K0K1MtNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.1.tgz",
+      "integrity": "sha512-WiCihJJpVWVEUxxZjhTbnG3Zq3q38XylKnvNelkVHbF+Y3+SXWN0Yyhk43J642G/d87lw1t60Tor0k96eaz4vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.2.tgz",
+      "integrity": "sha512-TVQFGttaNCcIvy1MKavb9ZihJmng46uUtVF9oTG/VI/C4YEdzekteI6iSsXbjv5ZAvOKQR+S25IWCbK2W0YCjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/meter": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.10.tgz",
+      "integrity": "sha512-soimx+MAngG5MjQplJNB9erPh+P3Er764PqGA75L6FFmf2KhgzMniSVAqyVOpZu7G3qK4O+ihMAYXf6pQMBkSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/progress": "^3.5.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.12",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.12.tgz",
+      "integrity": "sha512-cI0Grj+iW5840gV80t7aXt7FZPbxMZufjuAop5taHe6RlHuLuODfz5n3kyu/NPHabruF26mVEu0BfIrwZyy+VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.8.16",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.16.tgz",
+      "integrity": "sha512-Aj9jIFwALk9LiOV/s3rVie+vr5qWfaJp/6aGOuc2StSNDTHvj1urSAr3T0bT8wDlkrqnlS4JjEGE40ypfOkbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.13.tgz",
+      "integrity": "sha512-+4v++AP2xxYxjrTkIXlWWGUhPPIEBzyg76EW0SHKnD4pXxKigcIXEzRbxy62SMidTVdi7jh3tuicIP8OQxJ4cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/provider": {
+      "version": "3.8.10",
+      "resolved": "https://registry.npmjs.org/@react-types/provider/-/provider-3.8.10.tgz",
+      "integrity": "sha512-HnmP3JgWLC3OS0nvT+JhhfME3YG5SWzq/Qb4xHuONpx4s+v/EiZhdfuf5kHNRKnX+91mP/LR7vpRbSjGPWwCkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.8.10",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.8.10.tgz",
+      "integrity": "sha512-hLOu2CXxzxQqkEkXSM71jEJMnU5HvSzwQ+DbJISDjgfgAKvZZHMQX94Fht2Vj+402OdI77esl3pJ1tlSLyV5VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/searchfield": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.3.tgz",
+      "integrity": "sha512-Uua7TYKR1QcJE2F4SAewxuxt8k8gd52zul2q5oMe5azsm2uoAtV/qpNHc7dfPAR97UgbrE/aNMlX57PEubiuLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0",
+        "@react-types/textfield": "^3.12.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.9.13",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.13.tgz",
+      "integrity": "sha512-R7zwck353RV60gZimZ8pDKaj50aEtGzU8gk0jC3aBkfzSUKFJ6jq1DJdqyVQSwXdmPDd9iuketeIUIpEO2teoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.30.0.tgz",
+      "integrity": "sha512-COIazDAx1ncDg046cTJ8SFYsX8aS3lB/08LDnbkH/SkdYrFPWDlXMrO/sUam8j1WWM+PJ+4d1mj7tODIKNiFog==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.7.12",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.7.12.tgz",
+      "integrity": "sha512-kOQLrENLpQzmu6TfavdW1yfEc8VPitT4ZNMKOK0h7x3LskEWjptxcZ4IBowEpqHwk0eMbI9lRE/3tsShGUoLwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/statuslight": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/statuslight/-/statuslight-3.3.18.tgz",
+      "integrity": "sha512-LeZxO+3GMlw4Lw+cm/y1UTJaKsaVHKiXSvo/yb1kKz+STiIdKslXRIIKNYkSn3uf9z3qDiAuufuFwhvLsxS3tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.12.tgz",
+      "integrity": "sha512-6Zz7i+L9k8zw2c3nO8XErxuIy7JVDptz1NTZMiUeyDtLmQnvEKnKPKNjo2j+C/OngtJqAPowC3xRvMXbSAcYqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.1.tgz",
+      "integrity": "sha512-fLPRXrZoplAGMjqxHVLMt7lB0qsiu1WHZmhKtroCEhTYwnLQKL84XFH4GV1sQgQ1GIShl3BUqWzrawU5tEaQkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.16.tgz",
+      "integrity": "sha512-z6AWq243EahGuT4PhIpJXZbFez6XhFWb4KwhSB2CqzHkG5bJJSgKYzIcNuBCLDxO7Qg25I+VpFJxGj+aqKFbzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/text": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/text/-/text-3.3.18.tgz",
+      "integrity": "sha512-W1kwUQ7Fnq82V/Xp4dJkWu/7yuzp8rn/XoK95E5gVyMLkTsoyctlLJDgdn6WtS8WWuqG/nzYh7RrcWmdmg4e2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.3.tgz",
+      "integrity": "sha512-72tt2GJSyVFPPqZLrlfWqVn5KRnWzXsXCZ3IDawcGunl4pu+2E24jd0CWN9kOi0ETO65flj2sljeytxKytXnlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.18.tgz",
+      "integrity": "sha512-/eG8hiW0D4vaCqGDa4ttb+Jnbiz6nUr5+f+LRgz3AnIkdjS9eOhpn6vXMX4hkNgcN5FGfA4Uu1C1QdM6W97Kfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.16",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/view": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/@react-types/view/-/view-3.4.18.tgz",
+      "integrity": "sha512-J6qLINhkX8UAd+6JtwCR8OMuQxLxm1UA2Pu+j5ExpOrv6nOj4cQb9UPUAkEO89DPeUUEiNql6eEg0+I9ZSGp4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/well": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/@react-types/well/-/well-3.3.18.tgz",
+      "integrity": "sha512-l874XCNUh00xunmyOBJ1x8oKM2VBgkWb2+uS5xcvGeZa5phnglshdmASyfoaFpFlfzLJCWTYbk7C5WF+5nPOUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.11.tgz",
@@ -4116,6 +7608,38 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@spectrum-icons/ui": {
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/ui/-/ui-3.6.17.tgz",
+      "integrity": "sha512-pLDyxYrmZCla3arcnkCgxK1Gzow9RMaIidstOxeEKqKmW41pAlT3rwKtmVKrwi/hyx2abEb8wpiBErefXMPTNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum-ui": "1.2.1",
+        "@react-spectrum/icon": "^3.8.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@spectrum-icons/workflow": {
+      "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@spectrum-icons/workflow/-/workflow-4.2.22.tgz",
+      "integrity": "sha512-Yxqnfiw75g5tjygtw1B0E86yXhs5I/wSy4DbLLjheMvzqP+MlNu6I6rB74yCztyreR9/skDvEOsD/Gyd+SRr2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/react-spectrum-workflow": "2.3.5",
+        "@react-spectrum/icon": "^3.8.6",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@react-spectrum/provider": "^3.0.0",
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@storybook/addon-docs": {
       "version": "9.0.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.0.12.tgz",
@@ -4382,6 +7906,15 @@
       "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6367,6 +9900,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6420,6 +9959,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -6618,7 +10166,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -6711,7 +10258,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6879,6 +10425,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8318,6 +11874,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true,
+      "license": "(Apache-2.0 OR MPL-1.1)"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8490,6 +12053,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -8610,6 +12186,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-arguments": {
@@ -11304,7 +14892,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12122,7 +15709,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -12134,7 +15720,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/psl": {
@@ -12243,6 +15828,100 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.41.1.tgz",
+      "integrity": "sha512-5mujwnW6/NHvONDecb7DiWkzI27dzBO1auKt4KkgNuW+Awud1LCaK/NOlHp4xZl3fSfh1ROpdAKERHCh7nvAAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/breadcrumbs": "^3.5.26",
+        "@react-aria/button": "^3.13.3",
+        "@react-aria/calendar": "^3.8.3",
+        "@react-aria/checkbox": "^3.15.7",
+        "@react-aria/color": "^3.0.9",
+        "@react-aria/combobox": "^3.12.5",
+        "@react-aria/datepicker": "^3.14.5",
+        "@react-aria/dialog": "^3.5.27",
+        "@react-aria/disclosure": "^3.0.6",
+        "@react-aria/dnd": "^3.10.1",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/gridlist": "^3.13.2",
+        "@react-aria/i18n": "^3.12.10",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/label": "^3.7.19",
+        "@react-aria/landmark": "^3.0.4",
+        "@react-aria/link": "^3.8.3",
+        "@react-aria/listbox": "^3.14.6",
+        "@react-aria/menu": "^3.18.5",
+        "@react-aria/meter": "^3.4.24",
+        "@react-aria/numberfield": "^3.11.16",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/progress": "^3.4.24",
+        "@react-aria/radio": "^3.11.5",
+        "@react-aria/searchfield": "^3.8.6",
+        "@react-aria/select": "^3.15.7",
+        "@react-aria/selection": "^3.24.3",
+        "@react-aria/separator": "^3.4.10",
+        "@react-aria/slider": "^3.7.21",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/switch": "^3.7.5",
+        "@react-aria/table": "^3.17.5",
+        "@react-aria/tabs": "^3.10.5",
+        "@react-aria/tag": "^3.6.2",
+        "@react-aria/textfield": "^3.17.5",
+        "@react-aria/toast": "^3.0.5",
+        "@react-aria/tooltip": "^3.8.5",
+        "@react-aria/tree": "^3.1.1",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/visually-hidden": "^3.8.25",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.10.1.tgz",
+      "integrity": "sha512-Mllbk2pQax2EwlOJsXG4oTp6P7P33m82/47M9Os+zaGhSCqo2EilFvThxCFxhLa7ncjLV0ka6wFIYLmZiOcWxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/autocomplete": "3.0.0-beta.5",
+        "@react-aria/collections": "3.0.0-rc.3",
+        "@react-aria/dnd": "^3.10.1",
+        "@react-aria/focus": "^3.20.5",
+        "@react-aria/interactions": "^3.25.3",
+        "@react-aria/live-announcer": "^3.4.3",
+        "@react-aria/overlays": "^3.27.3",
+        "@react-aria/ssr": "^3.9.9",
+        "@react-aria/toolbar": "3.0.0-beta.18",
+        "@react-aria/utils": "^3.29.1",
+        "@react-aria/virtualizer": "^4.1.7",
+        "@react-stately/autocomplete": "3.0.0-beta.2",
+        "@react-stately/layout": "^4.3.1",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/utils": "^3.10.7",
+        "@react-stately/virtualizer": "^4.4.1",
+        "@react-types/form": "^3.7.13",
+        "@react-types/grid": "^3.3.3",
+        "@react-types/shared": "^3.30.0",
+        "@react-types/table": "^3.13.1",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "^3.41.1",
+        "react-stately": "^3.39.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.0.tgz",
@@ -12303,6 +15982,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.39.0.tgz",
+      "integrity": "sha512-/8JC3Tmj7G8fHn47F88c6t5kFNhQAufwqjEKxYeNi7TPz9UL+35BeoH1poMmDHJsPz8qM/z4sWMzaW5AwYK8lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/calendar": "^3.8.2",
+        "@react-stately/checkbox": "^3.6.15",
+        "@react-stately/collections": "^3.12.5",
+        "@react-stately/color": "^3.8.6",
+        "@react-stately/combobox": "^3.10.6",
+        "@react-stately/data": "^3.13.1",
+        "@react-stately/datepicker": "^3.14.2",
+        "@react-stately/disclosure": "^3.0.5",
+        "@react-stately/dnd": "^3.6.0",
+        "@react-stately/form": "^3.1.5",
+        "@react-stately/list": "^3.12.3",
+        "@react-stately/menu": "^3.9.5",
+        "@react-stately/numberfield": "^3.9.13",
+        "@react-stately/overlays": "^3.6.17",
+        "@react-stately/radio": "^3.10.14",
+        "@react-stately/searchfield": "^3.5.13",
+        "@react-stately/select": "^3.6.14",
+        "@react-stately/selection": "^3.20.3",
+        "@react-stately/slider": "^3.6.5",
+        "@react-stately/table": "^3.14.3",
+        "@react-stately/tabs": "^3.8.3",
+        "@react-stately/toast": "^3.1.1",
+        "@react-stately/toggle": "^3.8.5",
+        "@react-stately/tooltip": "^3.5.5",
+        "@react-stately/tree": "^3.9.0",
+        "@react-types/shared": "^3.30.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {
@@ -14109,7 +17841,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -14468,6 +18199,15 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.12.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@adobe/react-spectrum": "^3.42.2",
+    "@react-aria/i18n": "^3.12.10",
+    "@react-stately/data": "^3.13.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
@@ -70,7 +73,8 @@
     "typescript": "^5.3.3",
     "vite": "^6.3.5",
     "vite-plugin-pwa": "^1.0.0",
-    "workbox-window": "^7.0.0"
+    "workbox-window": "^7.0.0",
+    "identity-obj-proxy": "^3.0.0"
   },
   "files": [
     "dist",

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -4,6 +4,8 @@ import { EditorToolbar } from '../toolbar/component';
 import { ComponentPalette } from '../component-palette/component';
 import { EditorCanvas } from '../editor-canvas/component';
 import { ControlPanel } from '../control-panel/component';
+import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import { I18nProvider } from '@react-aria/i18n';
 
 /**
  * Main editor application using a simple flex layout
@@ -11,9 +13,12 @@ import { ControlPanel } from '../control-panel/component';
 export const EditorApp: React.FC = () => {
   const [theme, setTheme] = useState<EditorTheme>('light');
 
-  const handleThemeChange = useCallback((e: MediaQueryListEvent | MediaQueryList) => {
-    setTheme(e.matches ? 'dark' : 'light');
-  }, []);
+  const handleThemeChange = useCallback(
+    (e: MediaQueryListEvent | MediaQueryList) => {
+      setTheme(e.matches ? 'dark' : 'light');
+    },
+    []
+  );
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -26,38 +31,59 @@ export const EditorApp: React.FC = () => {
 
   const borderColor = theme === 'dark' ? '#374151' : '#e2e8f0';
 
-
   const handleThemeToggle = (newTheme: EditorTheme) => {
     setTheme(newTheme);
   };
 
   return (
-    <div
-      className="editor-container"
-      role="application"
-      aria-label="React Component Editor"
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        height: '100vh',
-        background: theme === 'dark' ? '#1e293b' : '#f8fafc',
-        color: theme === 'dark' ? '#f8fafc' : '#1e293b'
-      }}
-    >
-      <div style={{ height: '60px', borderBottom: `1px solid ${borderColor}`, background: theme === 'dark' ? '#374151' : 'white' }}>
-        <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
-      </div>
-      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-        <div style={{ width: '250px', borderRight: `1px solid ${borderColor}`, overflow: 'auto' }}>
-          <ComponentPalette theme={theme} aria-label="Component Library" />
+    <I18nProvider locale={navigator.language}>
+      <Provider theme={defaultTheme} colorScheme={theme}>
+        <div
+          className="editor-container"
+          role="application"
+          aria-label="React Component Editor"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100vh',
+            background: theme === 'dark' ? '#1e293b' : '#f8fafc',
+            color: theme === 'dark' ? '#f8fafc' : '#1e293b'
+          }}
+        >
+          <div
+            style={{
+              height: '60px',
+              borderBottom: `1px solid ${borderColor}`,
+              background: theme === 'dark' ? '#374151' : 'white'
+            }}
+          >
+            <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
+          </div>
+          <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+            <div
+              style={{
+                width: '250px',
+                borderRight: `1px solid ${borderColor}`,
+                overflow: 'auto'
+              }}
+            >
+              <ComponentPalette theme={theme} aria-label="Component Library" />
+            </div>
+            <div style={{ flex: 1, overflow: 'auto' }}>
+              <EditorCanvas theme={theme} aria-label="Design Canvas" />
+            </div>
+            <div
+              style={{
+                width: '300px',
+                borderLeft: `1px solid ${borderColor}`,
+                overflow: 'auto'
+              }}
+            >
+              <ControlPanel theme={theme} aria-label="Properties Panel" />
+            </div>
+          </div>
         </div>
-        <div style={{ flex: 1, overflow: 'auto' }}>
-          <EditorCanvas theme={theme} aria-label="Design Canvas" />
-        </div>
-        <div style={{ width: '300px', borderLeft: `1px solid ${borderColor}`, overflow: 'auto' }}>
-          <ControlPanel theme={theme} aria-label="Properties Panel" />
-        </div>
-      </div>
-    </div>
+      </Provider>
+    </I18nProvider>
   );
 };

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { EditorTheme } from '../../types/editor-types';
-import { Flex, ButtonGroup, Button, View } from '@adobe/react-spectrum';
+import { Flex, ButtonGroup, Button } from '@adobe/react-spectrum';
 import { useMessageFormatter } from '@react-aria/i18n';
 import messages from '../../i18n/toolbarMessages';
 
@@ -87,22 +87,23 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
         justifyContent="space-between"
       >
         <ButtonGroup>
-          <Button onPress={handleNew} aria-label={formatMessage('new')}>
+          <Button variant="primary" onPress={handleNew} aria-label={formatMessage('new')}>
             {formatMessage('new')}
           </Button>
-          <Button onPress={handleSave} aria-label={formatMessage('save')}>
+          <Button variant="primary" onPress={handleSave} aria-label={formatMessage('save')}>
             {formatMessage('save')}
           </Button>
-          <Button onPress={handleLoad} aria-label={formatMessage('load')}>
+          <Button variant="primary" onPress={handleLoad} aria-label={formatMessage('load')}>
             {formatMessage('load')}
           </Button>
-          <Button onPress={handleExport} aria-label={formatMessage('export')}>
+          <Button variant="primary" onPress={handleExport} aria-label={formatMessage('export')}>
             {formatMessage('export')}
           </Button>
         </ButtonGroup>
 
         <ButtonGroup>
           <Button
+            variant="secondary"
             onPress={handleUndo}
             isDisabled={!canUndo}
             aria-label={formatMessage('undo')}
@@ -110,6 +111,7 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             {formatMessage('undo')}
           </Button>
           <Button
+            variant="secondary"
             onPress={handleRedo}
             isDisabled={!canRedo}
             aria-label={formatMessage('redo')}
@@ -121,18 +123,21 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
         <Flex gap="size-100" alignItems="center">
           <span>{zoomLevel}%</span>
           <Button
+            variant="secondary"
             onPress={() => setZoomLevel((prev) => Math.max(10, prev - 10))}
             aria-label={formatMessage('zoomOut')}
           >
             −
           </Button>
           <Button
+            variant="secondary"
             onPress={() => setZoomLevel((prev) => Math.min(500, prev + 10))}
             aria-label={formatMessage('zoomIn')}
           >
             +
           </Button>
           <Button
+            variant="secondary"
             onPress={() => setZoomLevel(100)}
             aria-label={formatMessage('resetZoom')}
           >
@@ -142,6 +147,7 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
 
         <ButtonGroup>
           <Button
+            variant="primary"
             onPress={toggleTheme}
             aria-label={
               theme === 'light' ? formatMessage('dark') : formatMessage('light')

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import { EditorTheme } from '../../types/editor-types';
+import { Flex, ButtonGroup, Button, View } from '@adobe/react-spectrum';
+import { useMessageFormatter } from '@react-aria/i18n';
+import messages from '../../i18n/toolbarMessages';
 
 interface EditorToolbarProps {
   theme: EditorTheme;
@@ -16,7 +19,11 @@ interface EditorToolbarProps {
  * - Keyboard shortcuts for all actions
  * - Mobile-responsive layout
  */
-export const EditorToolbar: React.FC<EditorToolbarProps> = ({ theme, onThemeChange }) => {
+export const EditorToolbar: React.FC<EditorToolbarProps> = ({
+  theme,
+  onThemeChange
+}) => {
+  const formatMessage = useMessageFormatter(messages);
   const [zoomLevel, setZoomLevel] = useState(100);
   const [canUndo] = useState(false);
   const [canRedo] = useState(false);
@@ -71,182 +78,79 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({ theme, onThemeChan
     onThemeChange(theme === 'light' ? 'dark' : 'light');
   };
 
-  const buttonBaseStyle = {
-    padding: '8px 12px',
-    border: 'none',
-    borderRadius: '6px',
-    background: theme === 'dark' ? '#4b5563' : '#f3f4f6',
-    color: theme === 'dark' ? '#f8fafc' : '#374151',
-    cursor: 'pointer',
-    fontSize: '14px',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    transition: 'all 0.2s ease'
-  };
-
-  const buttonHoverStyle = {
-    ...buttonBaseStyle,
-    background: theme === 'dark' ? '#6b7280' : '#e5e7eb'
-  };
-
   return (
-    <div
-      className="editor-toolbar"
-      role="toolbar"
-      aria-label="Editor toolbar"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        padding: '12px 16px',
-        background: theme === 'dark' ? '#374151' : 'white',
-        borderBottom: `1px solid ${theme === 'dark' ? '#4b5563' : '#e2e8f0'}`,
-        gap: '12px',
-        flexWrap: 'wrap'
-      }}
-    >
-      {/* File operations */}
-      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-        <button
-          onClick={handleNew}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="New document (Ctrl+N)"
-          title="New document (Ctrl+N)"
-        >
-          <span aria-hidden="true">📄</span>
-          <span className="hidden sm:inline">New</span>
-        </button>
+    <div role="toolbar" aria-label={formatMessage('toolbar')}>
+      <Flex
+        gap="size-150"
+        wrap
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <ButtonGroup>
+          <Button onPress={handleNew} aria-label={formatMessage('new')}>
+            {formatMessage('new')}
+          </Button>
+          <Button onPress={handleSave} aria-label={formatMessage('save')}>
+            {formatMessage('save')}
+          </Button>
+          <Button onPress={handleLoad} aria-label={formatMessage('load')}>
+            {formatMessage('load')}
+          </Button>
+          <Button onPress={handleExport} aria-label={formatMessage('export')}>
+            {formatMessage('export')}
+          </Button>
+        </ButtonGroup>
 
-        <button
-          onClick={handleSave}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="Save document (Ctrl+S)"
-          title="Save document (Ctrl+S)"
-        >
-          <span aria-hidden="true">💾</span>
-          <span className="hidden sm:inline">Save</span>
-        </button>
+        <ButtonGroup>
+          <Button
+            onPress={handleUndo}
+            isDisabled={!canUndo}
+            aria-label={formatMessage('undo')}
+          >
+            {formatMessage('undo')}
+          </Button>
+          <Button
+            onPress={handleRedo}
+            isDisabled={!canRedo}
+            aria-label={formatMessage('redo')}
+          >
+            {formatMessage('redo')}
+          </Button>
+        </ButtonGroup>
 
-        <button
-          onClick={handleLoad}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="Load document (Ctrl+O)"
-          title="Load document (Ctrl+O)"
-        >
-          <span aria-hidden="true">📁</span>
-          <span className="hidden sm:inline">Load</span>
-        </button>
+        <Flex gap="size-100" alignItems="center">
+          <span>{zoomLevel}%</span>
+          <Button
+            onPress={() => setZoomLevel((prev) => Math.max(10, prev - 10))}
+            aria-label={formatMessage('zoomOut')}
+          >
+            −
+          </Button>
+          <Button
+            onPress={() => setZoomLevel((prev) => Math.min(500, prev + 10))}
+            aria-label={formatMessage('zoomIn')}
+          >
+            +
+          </Button>
+          <Button
+            onPress={() => setZoomLevel(100)}
+            aria-label={formatMessage('resetZoom')}
+          >
+            ⌂
+          </Button>
+        </Flex>
 
-        <button
-          onClick={handleExport}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="Export document"
-          title="Export document"
-        >
-          <span aria-hidden="true">📤</span>
-          <span className="hidden sm:inline">Export</span>
-        </button>
-      </div>
-
-      {/* Edit operations */}
-      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-        <button
-          onClick={handleUndo}
-          disabled={!canUndo}
-          style={{
-            ...buttonBaseStyle,
-            opacity: canUndo ? 1 : 0.5,
-            cursor: canUndo ? 'pointer' : 'not-allowed'
-          }}
-          aria-label="Undo (Ctrl+Z)"
-          title="Undo (Ctrl+Z)"
-        >
-          <span aria-hidden="true">↶</span>
-          <span className="hidden sm:inline">Undo</span>
-        </button>
-
-        <button
-          onClick={handleRedo}
-          disabled={!canRedo}
-          style={{
-            ...buttonBaseStyle,
-            opacity: canRedo ? 1 : 0.5,
-            cursor: canRedo ? 'pointer' : 'not-allowed'
-          }}
-          aria-label="Redo (Ctrl+Y)"
-          title="Redo (Ctrl+Y)"
-        >
-          <span aria-hidden="true">↷</span>
-          <span className="hidden sm:inline">Redo</span>
-        </button>
-      </div>
-
-      {/* Zoom controls */}
-      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-        <span
-          style={{
-            fontSize: '14px',
-            color: theme === 'dark' ? '#d1d5db' : '#6b7280',
-            whiteSpace: 'nowrap'
-          }}
-        >
-          {zoomLevel}%
-        </span>
-        <button
-          onClick={() => setZoomLevel(prev => Math.max(10, prev - 10))}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="Zoom out"
-          title="Zoom out"
-        >
-          <span aria-hidden="true">−</span>
-        </button>
-        <button
-          onClick={() => setZoomLevel(prev => Math.min(500, prev + 10))}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="Zoom in"
-          title="Zoom in"
-        >
-          <span aria-hidden="true">+</span>
-        </button>
-        <button
-          onClick={() => setZoomLevel(100)}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label="Reset zoom"
-          title="Reset zoom"
-        >
-          <span aria-hidden="true">⌂</span>
-        </button>
-      </div>
-
-      {/* Theme toggle */}
-      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-        <button
-          onClick={toggleTheme}
-          style={buttonBaseStyle}
-          onMouseEnter={(e) => Object.assign(e.currentTarget.style, buttonHoverStyle)}
-          onMouseLeave={(e) => Object.assign(e.currentTarget.style, buttonBaseStyle)}
-          aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
-          title={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
-        >
-          <span aria-hidden="true">{theme === 'light' ? '🌙' : '☀️'}</span>
-          <span className="hidden sm:inline">{theme === 'light' ? 'Dark' : 'Light'}</span>
-        </button>
-      </div>
+        <ButtonGroup>
+          <Button
+            onPress={toggleTheme}
+            aria-label={
+              theme === 'light' ? formatMessage('dark') : formatMessage('light')
+            }
+          >
+            {theme === 'light' ? formatMessage('dark') : formatMessage('light')}
+          </Button>
+        </ButtonGroup>
+      </Flex>
     </div>
   );
 };

--- a/src/i18n/toolbarMessages.ts
+++ b/src/i18n/toolbarMessages.ts
@@ -1,0 +1,31 @@
+export const toolbarMessages = {
+  'en-US': {
+    toolbar: 'Editor toolbar',
+    new: 'New',
+    save: 'Save',
+    load: 'Load',
+    export: 'Export',
+    undo: 'Undo',
+    redo: 'Redo',
+    zoomOut: 'Zoom out',
+    zoomIn: 'Zoom in',
+    resetZoom: 'Reset zoom',
+    dark: 'Dark',
+    light: 'Light'
+  },
+  'es-ES': {
+    toolbar: 'Barra de herramientas',
+    new: 'Nuevo',
+    save: 'Guardar',
+    load: 'Cargar',
+    export: 'Exportar',
+    undo: 'Deshacer',
+    redo: 'Rehacer',
+    zoomOut: 'Alejar',
+    zoomIn: 'Acercar',
+    resetZoom: 'Restablecer zoom',
+    dark: 'Oscuro',
+    light: 'Claro'
+  }
+};
+export default toolbarMessages;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,9 +51,6 @@ export default defineConfig({
                 maxEntries: 10,
                 maxAgeSeconds: 60 * 60 * 24 * 365 // <== 365 days
               },
-              cacheKeyWillBeUsed: async ({ request }) => {
-                return `${request.url}?version=1`;
-              }
             }
           }
         ]


### PR DESCRIPTION
## Summary
- add Adobe React Spectrum, React Aria i18n, and React Stately packages
- implement internationalized toolbar with React Spectrum components
- wrap the editor app in React Spectrum `Provider` and `I18nProvider`
- provide translation bundle for toolbar strings
- adjust jest config and setup for CSS modules and matchMedia
- update tests for new providers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853150b47488331b45d96a2f58b2172