### PR TITLE
Ensure deploy runs after checks succeed

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
+++ b/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
@@ -10,8 +10,51 @@ on:
       - main
 
 jobs:
+  lint:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint --if-present
+
+  build:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build --if-present
+
+  test:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test --silent
+
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    needs: [lint, build, test]
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     permissions:


### PR DESCRIPTION
## Summary
- gate the Azure Static Web Apps deploy job on build, lint, and test jobs

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68545e22b9f48331a23e81075813bb80