### PR TITLE
Build storybook as part of production output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 dist/
+storybook-static/
 
 
 # User-specific files

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ npm run build
 npm run preview
 ```
 
+The build script now outputs Storybook under `dist/storybook`, making the
+component documentation available at the `/storybook` endpoint in production.
+
 ## 📱 Mobile & Touch Support
 
 The editor is designed mobile-first with comprehensive touch gesture support:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && npm run build-storybook && mv storybook-static dist/storybook",
     "preview": "vite preview",
     "serve": "vite preview --port 3000",
     "lint": "eslint . --fix",


### PR DESCRIPTION
## Summary
- include storybook static files in the production `dist` folder
- ignore the generated storybook output
- document how to access Storybook in production

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find ESLint module)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68545cae04cc83318b639b7d185bcc08