### PR TITLE
Fix event loop performance issues

### DIFF
--- a/src/behaviors/useComponentTemplates.ts
+++ b/src/behaviors/useComponentTemplates.ts
@@ -77,9 +77,10 @@ export const useComponentTemplates = (
     }
   }, [templateUrl]);
 
+  // Load templates on initial mount or when the template URL changes
   useEffect(() => {
     loadTemplates();
-  });
+  }, [loadTemplates]);
 
   const reload = () => {
     loadTemplates();

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -28,7 +28,6 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
-  const animationIdRef = useRef<number | null>(null);
   const touchStartTimeRef = useRef(0);
   const longPressTimerRef = useRef<number | null>(null);
 
@@ -325,27 +324,18 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     setLastTouch(null);
   }, []);
 
-  // Initialize canvas and start render loop
+  // Initialize canvas on mount
   useEffect(() => {
     const cleanup = initializeCanvas();
-
-    const startRenderLoop = () => {
-      const render = () => {
-        renderCanvas();
-        animationIdRef.current = requestAnimationFrame(render);
-      };
-      render();
-    };
-
-    startRenderLoop();
-
     return () => {
-      if (animationIdRef.current) {
-        cancelAnimationFrame(animationIdRef.current);
-      }
       cleanup?.();
     };
-  }, [initializeCanvas, renderCanvas]);
+  }, [initializeCanvas]);
+
+  // Render canvas whenever relevant state changes
+  useEffect(() => {
+    renderCanvas();
+  }, [renderCanvas]);
 
   // Keyboard event listeners
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove rAF canvas loop and redraw only when state changes
- fetch component templates once instead of every render

## Testing
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68548ebe8eb483318605e691499da836