### PR TITLE
feat: use redux for canvas history

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
+++ b/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
@@ -67,35 +67,35 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     permissions:
-       id-token: write
-       contents: read
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
-          deployment_environment: ${{ github.head_ref || 'production' }}
         with:
           submodules: true
           lfs: false
+          deployment_environment: ${{ github.head_ref || 'production' }}
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
       - name: Get Id Token
         uses: actions/github-script@v6
         id: idtoken
         with:
-           script: |
-               const coredemo = require('@actions/core')
-               return await coredemo.getIDToken()
-           result-encoding: string
+          script: |
+            const coredemo = require('@actions/core')
+            return await coredemo.getIDToken()
+          result-encoding: string
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_KIND_BUSH_0DD23160F }}
-          action: "upload"
+          action: 'upload'
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "dist" # Built app content directory - optional
+          app_location: '/' # App source code path
+          api_location: '' # Api source code path - optional
+          output_location: 'dist' # Built app content directory - optional
           github_id_token: ${{ steps.idtoken.outputs.result }}
           ###### End of Repository/Build Configurations ######
 
@@ -108,4 +108,4 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
-          action: "close"
+          action: 'close'

--- a/__tests__/editor-canvas.test.tsx
+++ b/__tests__/editor-canvas.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EditorCanvas } from '../src/components/editor-canvas/component';
+import { Provider } from 'react-redux';
+import { store } from '../src/store';
 
 test('renders editor canvas', () => {
-  render(<EditorCanvas theme="light" />);
+  render(
+    <Provider store={store}>
+      <EditorCanvas theme="light" />
+    </Provider>
+  );
   const canvas = screen.getByRole('img', { name: /design canvas/i });
   expect(canvas).toBeInTheDocument();
 });

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EditorToolbar } from '../src/components/toolbar/component';
 import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import { Provider as ReduxProvider } from 'react-redux';
+import { store } from '../src/store';
 import { I18nProvider } from '@react-aria/i18n';
 
 test('renders toolbar', () => {
   render(
-    <I18nProvider locale="en-US">
-      <Provider theme={defaultTheme} colorScheme="light">
-        <EditorToolbar theme="light" onThemeChange={() => {}} />
-      </Provider>
-    </I18nProvider>
+    <ReduxProvider store={store}>
+      <I18nProvider locale="en-US">
+        <Provider theme={defaultTheme} colorScheme="light">
+          <EditorToolbar theme="light" onThemeChange={() => {}} />
+        </Provider>
+      </I18nProvider>
+    </ReduxProvider>
   );
   const toolbar = screen.getByRole('toolbar', { name: /editor toolbar/i });
   expect(toolbar).toBeInTheDocument();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,11 @@
     "@react-spectrum/provider": "^3.10.7",
     "@react-stately/data": "^3.13.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "redux": "^5.0.1",
+    "@reduxjs/toolkit": "^2.8.2",
+    "react-redux": "^9.2.0",
+    "redux-undo": "^1.1.0"
   },
   "devDependencies": {
     "@azure/static-web-apps-cli": "^2.0.6",

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -4,7 +4,12 @@ import { EditorToolbar } from '../toolbar/component';
 import { ComponentPalette } from '../component-palette/component';
 import { EditorCanvas } from '../editor-canvas/component';
 import { ControlPanel } from '../control-panel/component';
-import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import {
+  Provider as SpectrumProvider,
+  defaultTheme
+} from '@adobe/react-spectrum';
+import { Provider as ReduxProvider } from 'react-redux';
+import { store } from '../../store';
 import { I18nProvider } from '@react-aria/i18n';
 
 /**
@@ -36,54 +41,59 @@ export const EditorApp: React.FC = () => {
   };
 
   return (
-    <I18nProvider locale={navigator.language}>
-      <Provider theme={defaultTheme} colorScheme={theme}>
-        <div
-          className="editor-container"
-          role="application"
-          aria-label="React Component Editor"
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100vh',
-            background: theme === 'dark' ? '#1e293b' : '#f8fafc',
-            color: theme === 'dark' ? '#f8fafc' : '#1e293b'
-          }}
-        >
+    <ReduxProvider store={store}>
+      <I18nProvider locale={navigator.language}>
+        <SpectrumProvider theme={defaultTheme} colorScheme={theme}>
           <div
+            className="editor-container"
+            role="application"
+            aria-label="React Component Editor"
             style={{
-              height: '60px',
-              borderBottom: `1px solid ${borderColor}`,
-              background: theme === 'dark' ? '#374151' : 'white'
+              display: 'flex',
+              flexDirection: 'column',
+              height: '100vh',
+              background: theme === 'dark' ? '#1e293b' : '#f8fafc',
+              color: theme === 'dark' ? '#f8fafc' : '#1e293b'
             }}
           >
-            <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
-          </div>
-          <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
             <div
               style={{
-                width: '250px',
-                borderRight: `1px solid ${borderColor}`,
-                overflow: 'auto'
+                height: '60px',
+                borderBottom: `1px solid ${borderColor}`,
+                background: theme === 'dark' ? '#374151' : 'white'
               }}
             >
-              <ComponentPalette theme={theme} aria-label="Component Library" />
+              <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
             </div>
-            <div style={{ flex: 1, overflow: 'auto' }}>
-              <EditorCanvas theme={theme} aria-label="Design Canvas" />
-            </div>
-            <div
-              style={{
-                width: '300px',
-                borderLeft: `1px solid ${borderColor}`,
-                overflow: 'auto'
-              }}
-            >
-              <ControlPanel theme={theme} aria-label="Properties Panel" />
+            <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+              <div
+                style={{
+                  width: '250px',
+                  borderRight: `1px solid ${borderColor}`,
+                  overflow: 'auto'
+                }}
+              >
+                <ComponentPalette
+                  theme={theme}
+                  aria-label="Component Library"
+                />
+              </div>
+              <div style={{ flex: 1, overflow: 'auto' }}>
+                <EditorCanvas theme={theme} aria-label="Design Canvas" />
+              </div>
+              <div
+                style={{
+                  width: '300px',
+                  borderLeft: `1px solid ${borderColor}`,
+                  overflow: 'auto'
+                }}
+              >
+                <ControlPanel theme={theme} aria-label="Properties Panel" />
+              </div>
             </div>
           </div>
-        </div>
-      </Provider>
-    </I18nProvider>
+        </SpectrumProvider>
+      </I18nProvider>
+    </ReduxProvider>
   );
 };

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -4,6 +4,9 @@ import ZoomOut from '@spectrum-icons/workflow/ZoomOut';
 import ZoomIn from '@spectrum-icons/workflow/ZoomIn';
 import Refresh from '@spectrum-icons/workflow/Refresh';
 import { BaseComponent } from '../../types/component-base';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { setComponents } from '../../store';
+import { ActionCreators } from 'redux-undo';
 
 interface PinchState {
   startDistance: number;
@@ -24,7 +27,10 @@ interface EditorCanvasProps {
  * - Canvas rendering with zoom/pan
  * - Multi-touch gesture support
  */
-export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label': ariaLabel }) => {
+export const EditorCanvas: React.FC<EditorCanvasProps> = ({
+  theme,
+  'aria-label': ariaLabel
+}) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
@@ -35,14 +41,21 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     zoom: 1,
     pan: { x: 0, y: 0 },
     selectedComponents: [],
-    clipboard: [],
-    history: [],
-    historyIndex: -1
+    clipboard: []
   });
 
-  const [components, setComponents] = useState<BaseComponent[]>([]);
+  const dispatch = useAppDispatch();
+  const components = useAppSelector((state) => state.canvas.present.components);
   const [isDragging, setIsDragging] = useState(false);
   const [lastTouch, setLastTouch] = useState<PinchState | null>(null);
+
+  const handleUndo = useCallback(() => {
+    dispatch(ActionCreators.undo());
+  }, [dispatch]);
+
+  const handleRedo = useCallback(() => {
+    dispatch(ActionCreators.redo());
+  }, [dispatch]);
 
   const initializeCanvas = useCallback(() => {
     const canvas = canvasRef.current;
@@ -79,84 +92,118 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     };
   }, []);
 
-  const renderComponent = useCallback((component: BaseComponent) => {
-    const ctx = ctxRef.current;
-    if (!ctx) return;
+  const renderComponent = useCallback(
+    (component: BaseComponent) => {
+      const ctx = ctxRef.current;
+      if (!ctx) return;
 
-    const { bounds } = component;
+      const { bounds } = component;
 
-    // Render component background
-    ctx.fillStyle = String(component.properties.backgroundColor ?? '#ffffff');
-    ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+      // Render component background
+      ctx.fillStyle = String(component.properties.backgroundColor ?? '#ffffff');
+      ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
 
-    // Render component border
-    ctx.strokeStyle = String(component.properties.borderColor ?? '#e2e8f0');
-    ctx.lineWidth = Number(component.properties.borderWidth ?? 1);
-    ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+      // Render component border
+      ctx.strokeStyle = String(component.properties.borderColor ?? '#e2e8f0');
+      ctx.lineWidth = Number(component.properties.borderWidth ?? 1);
+      ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
 
-    // Render component content based on type
-    switch (component.type) {
-      case 'text':
-        ctx.fillStyle = String(component.properties.color ?? '#000000');
-        ctx.font = `${Number(component.properties.fontSize ?? 16)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
-        ctx.fillText(
-          String(component.properties.text ?? 'Text Component'),
-          bounds.x + 10,
-          bounds.y + bounds.height / 2 + 6
+      // Render component content based on type
+      switch (component.type) {
+        case 'text':
+          ctx.fillStyle = String(component.properties.color ?? '#000000');
+          ctx.font = `${Number(component.properties.fontSize ?? 16)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
+          ctx.fillText(
+            String(component.properties.text ?? 'Text Component'),
+            bounds.x + 10,
+            bounds.y + bounds.height / 2 + 6
+          );
+          break;
+
+        case 'button':
+          // Button background
+          ctx.fillStyle = String(
+            component.properties.backgroundColor ?? '#3b82f6'
+          );
+          ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+          // Button text
+          ctx.fillStyle = String(component.properties.color ?? '#ffffff');
+          ctx.font = `${Number(component.properties.fontSize ?? 14)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
+          ctx.textAlign = 'center';
+          ctx.fillText(
+            String(component.properties.text ?? 'Button'),
+            bounds.x + bounds.width / 2,
+            bounds.y + bounds.height / 2 + 4
+          );
+          ctx.textAlign = 'start';
+          break;
+
+        case 'image':
+          ctx.fillStyle = '#f3f4f6';
+          ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+          ctx.strokeStyle = '#d1d5db';
+          ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+          // Image icon
+          ctx.fillStyle = '#9ca3af';
+          ctx.font = '20px Arial';
+          ctx.textAlign = 'center';
+          ctx.fillText(
+            '🖼️',
+            bounds.x + bounds.width / 2,
+            bounds.y + bounds.height / 2 + 8
+          );
+          ctx.textAlign = 'start';
+          break;
+      }
+
+      // Render selection indicator
+      if (canvasState.selectedComponents.includes(component.id)) {
+        ctx.strokeStyle = '#3b82f6';
+        ctx.lineWidth = 2;
+        ctx.setLineDash([5, 5]);
+        ctx.strokeRect(
+          bounds.x - 2,
+          bounds.y - 2,
+          bounds.width + 4,
+          bounds.height + 4
         );
-        break;
+        ctx.setLineDash([]);
 
-      case 'button':
-        // Button background
-        ctx.fillStyle = String(component.properties.backgroundColor ?? '#3b82f6');
-        ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+        // Render resize handles
+        const handleSize = 8;
+        ctx.fillStyle = '#3b82f6';
 
-        // Button text
-        ctx.fillStyle = String(component.properties.color ?? '#ffffff');
-        ctx.font = `${Number(component.properties.fontSize ?? 14)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
-        ctx.textAlign = 'center';
-        ctx.fillText(
-          String(component.properties.text ?? 'Button'),
-          bounds.x + bounds.width / 2,
-          bounds.y + bounds.height / 2 + 4
+        // Corner handles
+        ctx.fillRect(
+          bounds.x - handleSize / 2,
+          bounds.y - handleSize / 2,
+          handleSize,
+          handleSize
         );
-        ctx.textAlign = 'start';
-        break;
-
-      case 'image':
-        ctx.fillStyle = '#f3f4f6';
-        ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
-        ctx.strokeStyle = '#d1d5db';
-        ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
-
-        // Image icon
-        ctx.fillStyle = '#9ca3af';
-        ctx.font = '20px Arial';
-        ctx.textAlign = 'center';
-        ctx.fillText('🖼️', bounds.x + bounds.width / 2, bounds.y + bounds.height / 2 + 8);
-        ctx.textAlign = 'start';
-        break;
-    }
-
-    // Render selection indicator
-    if (canvasState.selectedComponents.includes(component.id)) {
-      ctx.strokeStyle = '#3b82f6';
-      ctx.lineWidth = 2;
-      ctx.setLineDash([5, 5]);
-      ctx.strokeRect(bounds.x - 2, bounds.y - 2, bounds.width + 4, bounds.height + 4);
-      ctx.setLineDash([]);
-
-      // Render resize handles
-      const handleSize = 8;
-      ctx.fillStyle = '#3b82f6';
-
-      // Corner handles
-      ctx.fillRect(bounds.x - handleSize / 2, bounds.y - handleSize / 2, handleSize, handleSize);
-      ctx.fillRect(bounds.x + bounds.width - handleSize / 2, bounds.y - handleSize / 2, handleSize, handleSize);
-      ctx.fillRect(bounds.x - handleSize / 2, bounds.y + bounds.height - handleSize / 2, handleSize, handleSize);
-      ctx.fillRect(bounds.x + bounds.width - handleSize / 2, bounds.y + bounds.height - handleSize / 2, handleSize, handleSize);
-    }
-  }, [canvasState.selectedComponents]);
+        ctx.fillRect(
+          bounds.x + bounds.width - handleSize / 2,
+          bounds.y - handleSize / 2,
+          handleSize,
+          handleSize
+        );
+        ctx.fillRect(
+          bounds.x - handleSize / 2,
+          bounds.y + bounds.height - handleSize / 2,
+          handleSize,
+          handleSize
+        );
+        ctx.fillRect(
+          bounds.x + bounds.width - handleSize / 2,
+          bounds.y + bounds.height - handleSize / 2,
+          handleSize,
+          handleSize
+        );
+      }
+    },
+    [canvasState.selectedComponents]
+  );
 
   const renderCanvas = useCallback(() => {
     const ctx = ctxRef.current;
@@ -193,129 +240,173 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     }
 
     // Render components
-    components.forEach(component => {
+    components.forEach((component) => {
       renderComponent(component);
     });
 
     ctx.restore();
   }, [canvasState.pan, canvasState.zoom, components, renderComponent, theme]);
 
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    switch (e.key) {
-      case 'Delete':
-      case 'Backspace':
-        setComponents(prev => prev.filter(c => !canvasState.selectedComponents.includes(c.id)));
-        setCanvasState(prev => ({ ...prev, selectedComponents: [] }));
-        break;
-      case 'Escape':
-        setCanvasState(prev => ({ ...prev, selectedComponents: [] }));
-        break;
-      case 'a':
-        if (e.ctrlKey || e.metaKey) {
-          e.preventDefault();
-          setCanvasState(prev => ({ ...prev, selectedComponents: components.map(c => c.id) }));
-        }
-        break;
-    }
-  }, [canvasState.selectedComponents, components]);
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Delete':
+        case 'Backspace':
+          dispatch(
+            setComponents(
+              components.filter(
+                (c) => !canvasState.selectedComponents.includes(c.id)
+              )
+            )
+          );
+          setCanvasState((prev) => ({ ...prev, selectedComponents: [] }));
+          break;
+        case 'Escape':
+          setCanvasState((prev) => ({ ...prev, selectedComponents: [] }));
+          break;
+        case 'a':
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault();
+            setCanvasState((prev) => ({
+              ...prev,
+              selectedComponents: components.map((c) => c.id)
+            }));
+          }
+          break;
+        case 'z':
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault();
+            if (e.shiftKey) {
+              handleRedo();
+            } else {
+              handleUndo();
+            }
+          }
+          break;
+      }
+    },
+    [
+      canvasState.selectedComponents,
+      components,
+      handleUndo,
+      handleRedo,
+      dispatch
+    ]
+  );
 
-  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
 
-    const rect = canvas.getBoundingClientRect();
-    const x = (e.clientX - rect.left - canvasState.pan.x) / canvasState.zoom;
-    const y = (e.clientY - rect.top - canvasState.pan.y) / canvasState.zoom;
+      const rect = canvas.getBoundingClientRect();
+      const x = (e.clientX - rect.left - canvasState.pan.x) / canvasState.zoom;
+      const y = (e.clientY - rect.top - canvasState.pan.y) / canvasState.zoom;
 
-    // Check if clicking on a component
-    const clickedComponent = components.find(component =>
-      x >= component.bounds.x &&
-      x <= component.bounds.x + component.bounds.width &&
-      y >= component.bounds.y &&
-      y <= component.bounds.y + component.bounds.height
-    );
+      // Check if clicking on a component
+      const clickedComponent = components.find(
+        (component) =>
+          x >= component.bounds.x &&
+          x <= component.bounds.x + component.bounds.width &&
+          y >= component.bounds.y &&
+          y <= component.bounds.y + component.bounds.height
+      );
 
-    if (clickedComponent) {
-      setCanvasState(prev => ({
-        ...prev,
-        selectedComponents: e.shiftKey
-          ? [...prev.selectedComponents, clickedComponent.id]
-          : [clickedComponent.id]
-      }));
-      setIsDragging(true);
-    } else {
-      setCanvasState(prev => ({ ...prev, selectedComponents: [] }));
-    }
-  }, [canvasState.pan, canvasState.zoom, components]);
+      if (clickedComponent) {
+        setCanvasState((prev) => ({
+          ...prev,
+          selectedComponents: e.shiftKey
+            ? [...prev.selectedComponents, clickedComponent.id]
+            : [clickedComponent.id]
+        }));
+        setIsDragging(true);
+      } else {
+        setCanvasState((prev) => ({ ...prev, selectedComponents: [] }));
+      }
+    },
+    [canvasState.pan, canvasState.zoom, components]
+  );
 
-  const handleMouseMove = useCallback((_e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!isDragging) return;
+  const handleMouseMove = useCallback(
+    (_e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!isDragging) return;
 
-    // Handle dragging logic here
-    // This would update component positions based on mouse movement
-  }, [isDragging]);
+      // Handle dragging logic here
+      // This would update component positions based on mouse movement
+    },
+    [isDragging]
+  );
 
   const handleMouseUp = useCallback(() => {
     setIsDragging(false);
   }, []);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    touchStartTimeRef.current = Date.now();
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      touchStartTimeRef.current = Date.now();
 
-    // Handle multi-touch gestures
-    if (e.touches.length === 2) {
-      const touch1 = e.touches[0];
-      const touch2 = e.touches[1];
+      // Handle multi-touch gestures
+      if (e.touches.length === 2) {
+        const touch1 = e.touches[0];
+        const touch2 = e.touches[1];
 
-      const distance = Math.sqrt(
-        Math.pow(touch2.clientX - touch1.clientX, 2) +
-        Math.pow(touch2.clientY - touch1.clientY, 2)
-      );
+        const distance = Math.sqrt(
+          Math.pow(touch2.clientX - touch1.clientX, 2) +
+            Math.pow(touch2.clientY - touch1.clientY, 2)
+        );
 
-      setLastTouch({
-        startDistance: distance,
-        startZoom: canvasState.zoom,
-      });
-    }
-
-    // Long press detection
-    longPressTimerRef.current = window.setTimeout(() => {
-      // Handle long press (context menu, etc.)
-      if ('vibrate' in navigator) {
-        navigator.vibrate(50);
+        setLastTouch({
+          startDistance: distance,
+          startZoom: canvasState.zoom
+        });
       }
-    }, 500);
-  }, [canvasState.zoom]);
 
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
+      // Long press detection
+      longPressTimerRef.current = window.setTimeout(() => {
+        // Handle long press (context menu, etc.)
+        if ('vibrate' in navigator) {
+          navigator.vibrate(50);
+        }
+      }, 500);
+    },
+    [canvasState.zoom]
+  );
 
-    if (
-      e.touches.length === 2 &&
-      lastTouch?.startDistance !== undefined &&
-      lastTouch?.startZoom !== undefined
-    ) {
-      // Handle pinch-to-zoom
-      const touch1 = e.touches[0];
-      const touch2 = e.touches[1];
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
 
-      const distance = Math.sqrt(
-        Math.pow(touch2.clientX - touch1.clientX, 2) +
-        Math.pow(touch2.clientY - touch1.clientY, 2)
-      );
+      if (
+        e.touches.length === 2 &&
+        lastTouch?.startDistance !== undefined &&
+        lastTouch?.startZoom !== undefined
+      ) {
+        // Handle pinch-to-zoom
+        const touch1 = e.touches[0];
+        const touch2 = e.touches[1];
 
-      const scale = distance / lastTouch.startDistance!;
-      const newZoom = Math.max(0.1, Math.min(5, lastTouch.startZoom! * scale));
+        const distance = Math.sqrt(
+          Math.pow(touch2.clientX - touch1.clientX, 2) +
+            Math.pow(touch2.clientY - touch1.clientY, 2)
+        );
 
-      setCanvasState(prev => ({ ...prev, zoom: newZoom }));
-    } else if (e.touches.length === 1) {
-      // Handle single-touch pan
-      const canvas = canvasRef.current;
-      if (!canvas) return;
+        const scale = distance / lastTouch.startDistance!;
+        const newZoom = Math.max(
+          0.1,
+          Math.min(5, lastTouch.startZoom! * scale)
+        );
 
-      canvas.getBoundingClientRect();
-    }
-  }, [lastTouch]);
+        setCanvasState((prev) => ({ ...prev, zoom: newZoom }));
+      } else if (e.touches.length === 1) {
+        // Handle single-touch pan
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        canvas.getBoundingClientRect();
+      }
+    },
+    [lastTouch]
+  );
 
   const handleTouchEnd = useCallback(() => {
     if (longPressTimerRef.current) {
@@ -344,7 +435,6 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
-
 
   return (
     <div
@@ -392,7 +482,12 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
         }}
       >
         <button
-          onClick={() => setCanvasState(prev => ({ ...prev, zoom: Math.max(0.1, prev.zoom - 0.1) }))}
+          onClick={() =>
+            setCanvasState((prev) => ({
+              ...prev,
+              zoom: Math.max(0.1, prev.zoom - 0.1)
+            }))
+          }
           style={{
             padding: '8px 12px',
             border: 'none',
@@ -415,7 +510,12 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
           {Math.round(canvasState.zoom * 100)}%
         </span>
         <button
-          onClick={() => setCanvasState(prev => ({ ...prev, zoom: Math.min(5, prev.zoom + 0.1) }))}
+          onClick={() =>
+            setCanvasState((prev) => ({
+              ...prev,
+              zoom: Math.min(5, prev.zoom + 0.1)
+            }))
+          }
           style={{
             padding: '8px 12px',
             border: 'none',
@@ -429,7 +529,13 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
           <ZoomIn aria-hidden="true" size="S" />
         </button>
         <button
-          onClick={() => setCanvasState(prev => ({ ...prev, zoom: 1, pan: { x: 0, y: 0 } }))}
+          onClick={() =>
+            setCanvasState((prev) => ({
+              ...prev,
+              zoom: 1,
+              pan: { x: 0, y: 0 }
+            }))
+          }
           style={{
             padding: '8px 12px',
             border: 'none',

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { EditorTheme } from '../../types/editor-types';
 import { Flex, ButtonGroup, Button } from '@adobe/react-spectrum';
 import Add from '@spectrum-icons/workflow/Add';
@@ -11,6 +11,8 @@ import Moon from '@spectrum-icons/workflow/Moon';
 import Light from '@spectrum-icons/workflow/Light';
 import { useMessageFormatter } from '@react-aria/i18n';
 import messages from '../../i18n/toolbarMessages';
+import { useAppDispatch } from '../../store';
+import { ActionCreators } from 'redux-undo';
 
 interface EditorToolbarProps {
   theme: EditorTheme;
@@ -32,17 +34,14 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
   onThemeChange
 }) => {
   const formatMessage = useMessageFormatter(messages);
-  const [canUndo] = useState(false);
-  const [canRedo] = useState(false);
+  const dispatch = useAppDispatch();
 
   const handleUndo = () => {
-    // Dispatch undo event or call undo handler
-    console.log('Undo action');
+    dispatch(ActionCreators.undo());
   };
 
   const handleRedo = () => {
-    // Dispatch redo event or call redo handler
-    console.log('Redo action');
+    dispatch(ActionCreators.redo());
   };
 
   const handleNew = () => {
@@ -94,16 +93,32 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
         justifyContent="space-between"
       >
         <ButtonGroup>
-          <Button variant="primary" onPress={handleNew} aria-label={formatMessage('new')}>
+          <Button
+            variant="primary"
+            onPress={handleNew}
+            aria-label={formatMessage('new')}
+          >
             <Add aria-hidden="true" size="S" />
           </Button>
-          <Button variant="primary" onPress={handleSave} aria-label={formatMessage('save')}>
+          <Button
+            variant="primary"
+            onPress={handleSave}
+            aria-label={formatMessage('save')}
+          >
             <SaveFloppy aria-hidden="true" size="S" />
           </Button>
-          <Button variant="primary" onPress={handleLoad} aria-label={formatMessage('load')}>
+          <Button
+            variant="primary"
+            onPress={handleLoad}
+            aria-label={formatMessage('load')}
+          >
             <OpenIn aria-hidden="true" size="S" />
           </Button>
-          <Button variant="primary" onPress={handleExport} aria-label={formatMessage('export')}>
+          <Button
+            variant="primary"
+            onPress={handleExport}
+            aria-label={formatMessage('export')}
+          >
             <ExportIcon aria-hidden="true" size="S" />
           </Button>
         </ButtonGroup>
@@ -112,7 +127,6 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
           <Button
             variant="secondary"
             onPress={handleUndo}
-            isDisabled={!canUndo}
             aria-label={formatMessage('undo')}
           >
             <UndoIcon aria-hidden="true" size="S" />
@@ -120,13 +134,11 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
           <Button
             variant="secondary"
             onPress={handleRedo}
-            isDisabled={!canRedo}
             aria-label={formatMessage('redo')}
           >
             <RedoIcon aria-hidden="true" size="S" />
           </Button>
         </ButtonGroup>
-
 
         <ButtonGroup>
           <Button

--- a/src/store/canvasSlice.ts
+++ b/src/store/canvasSlice.ts
@@ -1,0 +1,67 @@
+import { AnyAction } from 'redux';
+import undoable from 'redux-undo';
+import type { BaseComponent } from '../types/component-base';
+
+export interface CanvasState {
+  components: BaseComponent[];
+}
+
+const initialState: CanvasState = {
+  components: []
+};
+
+export const setComponents = (components: BaseComponent[]) => ({
+  type: 'canvas/set' as const,
+  payload: components
+});
+
+export const addComponent = (component: BaseComponent) => ({
+  type: 'canvas/add' as const,
+  payload: component
+});
+
+export const removeComponent = (id: string) => ({
+  type: 'canvas/remove' as const,
+  payload: id
+});
+
+export const updateComponent = (component: BaseComponent) => ({
+  type: 'canvas/update' as const,
+  payload: component
+});
+
+export type CanvasActions =
+  | ReturnType<typeof setComponents>
+  | ReturnType<typeof addComponent>
+  | ReturnType<typeof removeComponent>
+  | ReturnType<typeof updateComponent>;
+
+const reducer = (
+  state: CanvasState = initialState,
+  action: CanvasActions
+): CanvasState => {
+  switch (action.type) {
+    case 'canvas/set':
+      return { ...state, components: action.payload };
+    case 'canvas/add':
+      return { ...state, components: [...state.components, action.payload] };
+    case 'canvas/remove':
+      return {
+        ...state,
+        components: state.components.filter((c) => c.id !== action.payload)
+      };
+    case 'canvas/update':
+      return {
+        ...state,
+        components: state.components.map((c) =>
+          c.id === action.payload.id ? action.payload : c
+        )
+      };
+    default:
+      return state;
+  }
+};
+
+export const canvasReducer = undoable<CanvasState, AnyAction>(
+  reducer as (state: CanvasState | undefined, action: AnyAction) => CanvasState
+);

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export * from './store';
+export * from './canvasSlice';
+export * from './hooks';

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { canvasReducer } from './canvasSlice';
+
+export const store = configureStore({
+  reducer: {
+    canvas: canvasReducer
+  }
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/types/editor-types.ts
+++ b/src/types/editor-types.ts
@@ -1,4 +1,8 @@
-import type { BaseComponent, ComponentProperties, ComponentPropertyValue } from "./component-base";
+import type {
+  BaseComponent,
+  ComponentProperties,
+  ComponentPropertyValue
+} from './component-base';
 export type EditorTheme = 'light' | 'dark';
 
 export interface Point {
@@ -11,7 +15,7 @@ export interface Size {
   height: number;
 }
 
-export interface Bounds extends Point, Size { }
+export interface Bounds extends Point, Size {}
 
 export interface EditorComponent {
   id: string;
@@ -64,8 +68,6 @@ export interface CanvasState {
   pan: Point;
   selectedComponents: string[];
   clipboard: BaseComponent[];
-  history: BaseComponent[][];
-  historyIndex: number;
 }
 
 export interface AccessibilityOptions {


### PR DESCRIPTION
## Summary
- add Redux store with undoable canvas slice
- wrap `EditorApp` with Redux provider
- connect `EditorCanvas` and `EditorToolbar` to Redux actions for undo/redo
- update tests for Redux provider

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854a0bf898c8331a43b3234c86838fc