### PR TITLE
Update workflows to share build artifacts

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
+++ b/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install deps if lock missing
         if: ${{ hashFiles('package-lock.json') == '' }}
         run: npm install
@@ -37,12 +37,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install deps if lock missing
         if: ${{ hashFiles('package-lock.json') == '' }}
         run: npm install
       - run: npm ci
       - run: npm run build --if-present
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
 
   test:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
@@ -54,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install deps if lock missing
         if: ${{ hashFiles('package-lock.json') == '' }}
         run: npm install
@@ -70,6 +75,10 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -93,6 +102,7 @@ jobs:
           action: 'upload'
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          skip_app_build: true
           app_location: '/' # App source code path
           api_location: '' # Api source code path - optional
           output_location: 'dist' # Built app content directory - optional

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install deps if lock missing
         if: ${{ hashFiles('package-lock.json') == '' }}
         run: npm install
       - run: npm ci
       - run: npm run build --if-present
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install deps if lock missing
         if: ${{ hashFiles('package-lock.json') == '' }}
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: Install deps if lock missing
         if: ${{ hashFiles('package-lock.json') == '' }}
         run: npm install


### PR DESCRIPTION
## Summary
- build artifacts in the CI workflow
- run Node.js 22 in all jobs
- deploy using pre-built assets

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6854e2e8c4348331accc27ebf5b839af