### PR TITLE
feat: store canvas zoom and pan in redux

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ A generic HTML5-based React editor built as a PWA (Progressive Web App) with com
 ## ✨ Features
 
 ### Core Functionality
+
 - **HTML5 Canvas Editor** - High-performance canvas-based editing with zoom, pan, and multi-selection
-- **Component Palette** - Drag-and-drop component library with search and categorization  
+- **Component Palette** - Drag-and-drop component library with search and categorization
 - **Property Panel** - Dynamic property editing with type-specific controls
 - **PWA Support** - Installable app with offline capabilities and service worker
+- **Undo/Redo History** - Centralized Redux store with history management
 - **Responsive Design** - Mobile-first design that adapts to desktop and tablet
 
 ### Accessibility & Inclusion
+
 - **WCAG 2.1 AA Compliant** - Screen reader support, keyboard navigation, focus management
 - **Touch-First Design** - Optimized for touch devices with gesture recognition
 - **High Contrast Support** - Automatic adaptation to user contrast preferences
@@ -23,6 +26,7 @@ A generic HTML5-based React editor built as a PWA (Progressive Web App) with com
 - **Keyboard Shortcuts** - Full keyboard accessibility for power users
 
 ### Technical Features
+
 - **TypeScript** - Full type safety and excellent developer experience
 - **React 18** - Modern React with hooks and functional components
 - **Tailwind CSS** - Utility-first styling with consistent design system
@@ -32,6 +36,7 @@ A generic HTML5-based React editor built as a PWA (Progressive Web App) with com
 ## 🚀 Quick Start
 
 ### Prerequisites
+
 - Node.js 22+
 - npm 11+
 
@@ -74,18 +79,21 @@ The editor is designed mobile-first with comprehensive touch gesture support:
 ## ♿ Accessibility Features
 
 ### Screen Reader Support
+
 - Semantic HTML structure with proper ARIA labels
 - Live regions for dynamic content updates
 - Comprehensive keyboard navigation
 - Screen reader announcements for user actions
 
 ### Keyboard Navigation
+
 - **Tab/Shift+Tab** - Navigate between focusable elements
 - **Enter/Space** - Activate buttons and components
 - **Arrow Keys** - Navigate within component groups
 - **Escape** - Cancel operations and clear selections
 
 ### Visual Accessibility
+
 - High contrast mode support
 - Customizable color themes (light/dark)
 - Scalable fonts and UI elements
@@ -96,18 +104,23 @@ The editor is designed mobile-first with comprehensive touch gesture support:
 ### Core Panels
 
 #### `editor-app`
+
 Main application panel that orchestrates the canvas panel, palette panel, and control panel.
 
 #### `editor-canvas`
+
 HTML5 canvas-based editor panel with touch support, zoom/pan, and component rendering.
 
 #### `component-palette`
+
 Drag-and-drop component library panel with search, categorization, and keyboard accessibility.
 
 #### `control-panel`
+
 Dynamic property panel with type-specific controls for selected components.
 
 #### `editor-toolbar`
+
 Application toolbar with file operations, undo/redo, zoom controls, and theme toggle.
 
 ### Type System
@@ -169,6 +182,7 @@ npm run type-check   # TypeScript type checking
 ### Adding New Components
 
 1. **Define Component Type**
+
 ```typescript
 // Add to component definitions
 {
@@ -187,6 +201,7 @@ npm run type-check   # TypeScript type checking
 ```
 
 2. **Implement Rendering**
+
 ```typescript
 // Add to canvas component rendering
 case 'my-component':
@@ -195,6 +210,7 @@ case 'my-component':
 ```
 
 3. **Add Property Schema**
+
 ```typescript
 // Define editable properties
 {
@@ -222,15 +238,19 @@ The editor supports light and dark themes with CSS custom properties:
 ## 🧪 Testing
 
 ### Unit Tests
+
 ```bash
 npm run test          # Run all tests
 ```
 
 ### Accessibility Testing
+
 The project includes automated accessibility testing and follows WCAG 2.1 AA guidelines.
 
 ### Browser Testing
+
 Tested and supported on:
+
 - Chrome/Chromium 90+
 - Firefox 88+
 - Safari 14+
@@ -240,6 +260,7 @@ Tested and supported on:
 ## 📦 Deployment
 
 ### Static Hosting
+
 The built application can be deployed to any static hosting service:
 
 ```bash
@@ -248,6 +269,7 @@ npm run build
 ```
 
 ### PWA Features
+
 - **Service Worker** - Automatic caching and offline support
 - **Web App Manifest** - Installable app experience
 - **Background Sync** - Offline operation support
@@ -257,6 +279,7 @@ npm run build
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
 ### Development Setup
+
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/amazing-feature`
 3. Make your changes and add tests
@@ -266,6 +289,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 7. Open a Pull Request
 
 ### Code Standards
+
 - **ESLint** - Code linting with TypeScript rules
 - **Prettier** - Code formatting
 - **Conventional Commits** - Commit message format

--- a/__tests__/editor-canvas.test.tsx
+++ b/__tests__/editor-canvas.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EditorCanvas } from '../src/components/editor-canvas/component';
+import { Provider } from 'react-redux';
+import { store } from '../src/store';
 
 test('renders editor canvas', () => {
-  render(<EditorCanvas theme="light" />);
+  render(
+    <Provider store={store}>
+      <EditorCanvas theme="light" />
+    </Provider>
+  );
   const canvas = screen.getByRole('img', { name: /design canvas/i });
   expect(canvas).toBeInTheDocument();
 });

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -2,15 +2,19 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EditorToolbar } from '../src/components/toolbar/component';
 import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import { Provider as ReduxProvider } from 'react-redux';
+import { store } from '../src/store';
 import { I18nProvider } from '@react-aria/i18n';
 
 test('renders toolbar', () => {
   render(
-    <I18nProvider locale="en-US">
-      <Provider theme={defaultTheme} colorScheme="light">
-        <EditorToolbar theme="light" onThemeChange={() => {}} />
-      </Provider>
-    </I18nProvider>
+    <ReduxProvider store={store}>
+      <I18nProvider locale="en-US">
+        <Provider theme={defaultTheme} colorScheme="light">
+          <EditorToolbar theme="light" onThemeChange={() => {}} />
+        </Provider>
+      </I18nProvider>
+    </ReduxProvider>
   );
   const toolbar = screen.getByRole('toolbar', { name: /editor toolbar/i });
   expect(toolbar).toBeInTheDocument();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,11 @@
     "@react-spectrum/provider": "^3.10.7",
     "@react-stately/data": "^3.13.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "redux": "^5.0.1",
+    "@reduxjs/toolkit": "^2.8.2",
+    "react-redux": "^9.2.0",
+    "redux-undo": "^1.1.0"
   },
   "devDependencies": {
     "@azure/static-web-apps-cli": "^2.0.6",

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -4,7 +4,12 @@ import { EditorToolbar } from '../toolbar/component';
 import { ComponentPalette } from '../component-palette/component';
 import { EditorCanvas } from '../editor-canvas/component';
 import { ControlPanel } from '../control-panel/component';
-import { Provider, defaultTheme } from '@adobe/react-spectrum';
+import {
+  Provider as SpectrumProvider,
+  defaultTheme
+} from '@adobe/react-spectrum';
+import { Provider as ReduxProvider } from 'react-redux';
+import { store } from '../../store';
 import { I18nProvider } from '@react-aria/i18n';
 
 /**
@@ -36,54 +41,59 @@ export const EditorApp: React.FC = () => {
   };
 
   return (
-    <I18nProvider locale={navigator.language}>
-      <Provider theme={defaultTheme} colorScheme={theme}>
-        <div
-          className="editor-container"
-          role="application"
-          aria-label="React Component Editor"
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100vh',
-            background: theme === 'dark' ? '#1e293b' : '#f8fafc',
-            color: theme === 'dark' ? '#f8fafc' : '#1e293b'
-          }}
-        >
+    <ReduxProvider store={store}>
+      <I18nProvider locale={navigator.language}>
+        <SpectrumProvider theme={defaultTheme} colorScheme={theme}>
           <div
+            className="editor-container"
+            role="application"
+            aria-label="React Component Editor"
             style={{
-              height: '60px',
-              borderBottom: `1px solid ${borderColor}`,
-              background: theme === 'dark' ? '#374151' : 'white'
+              display: 'flex',
+              flexDirection: 'column',
+              height: '100vh',
+              background: theme === 'dark' ? '#1e293b' : '#f8fafc',
+              color: theme === 'dark' ? '#f8fafc' : '#1e293b'
             }}
           >
-            <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
-          </div>
-          <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
             <div
               style={{
-                width: '250px',
-                borderRight: `1px solid ${borderColor}`,
-                overflow: 'auto'
+                height: '60px',
+                borderBottom: `1px solid ${borderColor}`,
+                background: theme === 'dark' ? '#374151' : 'white'
               }}
             >
-              <ComponentPalette theme={theme} aria-label="Component Library" />
+              <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
             </div>
-            <div style={{ flex: 1, overflow: 'auto' }}>
-              <EditorCanvas theme={theme} aria-label="Design Canvas" />
-            </div>
-            <div
-              style={{
-                width: '300px',
-                borderLeft: `1px solid ${borderColor}`,
-                overflow: 'auto'
-              }}
-            >
-              <ControlPanel theme={theme} aria-label="Properties Panel" />
+            <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+              <div
+                style={{
+                  width: '250px',
+                  borderRight: `1px solid ${borderColor}`,
+                  overflow: 'auto'
+                }}
+              >
+                <ComponentPalette
+                  theme={theme}
+                  aria-label="Component Library"
+                />
+              </div>
+              <div style={{ flex: 1, overflow: 'auto' }}>
+                <EditorCanvas theme={theme} aria-label="Design Canvas" />
+              </div>
+              <div
+                style={{
+                  width: '300px',
+                  borderLeft: `1px solid ${borderColor}`,
+                  overflow: 'auto'
+                }}
+              >
+                <ControlPanel theme={theme} aria-label="Properties Panel" />
+              </div>
             </div>
           </div>
-        </div>
-      </Provider>
-    </I18nProvider>
+        </SpectrumProvider>
+      </I18nProvider>
+    </ReduxProvider>
   );
 };

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -4,6 +4,9 @@ import ZoomOut from '@spectrum-icons/workflow/ZoomOut';
 import ZoomIn from '@spectrum-icons/workflow/ZoomIn';
 import Refresh from '@spectrum-icons/workflow/Refresh';
 import { BaseComponent } from '../../types/component-base';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { setComponents, setZoom, setPan } from '../../store';
+import { ActionCreators } from 'redux-undo';
 
 interface PinchState {
   startDistance: number;
@@ -24,7 +27,10 @@ interface EditorCanvasProps {
  * - Canvas rendering with zoom/pan
  * - Multi-touch gesture support
  */
-export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label': ariaLabel }) => {
+export const EditorCanvas: React.FC<EditorCanvasProps> = ({
+  theme,
+  'aria-label': ariaLabel
+}) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
@@ -32,17 +38,24 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
   const longPressTimerRef = useRef<number | null>(null);
 
   const [canvasState, setCanvasState] = useState<CanvasState>({
-    zoom: 1,
-    pan: { x: 0, y: 0 },
     selectedComponents: [],
-    clipboard: [],
-    history: [],
-    historyIndex: -1
+    clipboard: []
   });
 
-  const [components, setComponents] = useState<BaseComponent[]>([]);
+  const dispatch = useAppDispatch();
+  const components = useAppSelector((state) => state.canvas.present.components);
+  const zoom = useAppSelector((state) => state.canvas.present.zoom);
+  const pan = useAppSelector((state) => state.canvas.present.pan);
   const [isDragging, setIsDragging] = useState(false);
   const [lastTouch, setLastTouch] = useState<PinchState | null>(null);
+
+  const handleUndo = useCallback(() => {
+    dispatch(ActionCreators.undo());
+  }, [dispatch]);
+
+  const handleRedo = useCallback(() => {
+    dispatch(ActionCreators.redo());
+  }, [dispatch]);
 
   const initializeCanvas = useCallback(() => {
     const canvas = canvasRef.current;
@@ -79,84 +92,118 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     };
   }, []);
 
-  const renderComponent = useCallback((component: BaseComponent) => {
-    const ctx = ctxRef.current;
-    if (!ctx) return;
+  const renderComponent = useCallback(
+    (component: BaseComponent) => {
+      const ctx = ctxRef.current;
+      if (!ctx) return;
 
-    const { bounds } = component;
+      const { bounds } = component;
 
-    // Render component background
-    ctx.fillStyle = String(component.properties.backgroundColor ?? '#ffffff');
-    ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+      // Render component background
+      ctx.fillStyle = String(component.properties.backgroundColor ?? '#ffffff');
+      ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
 
-    // Render component border
-    ctx.strokeStyle = String(component.properties.borderColor ?? '#e2e8f0');
-    ctx.lineWidth = Number(component.properties.borderWidth ?? 1);
-    ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+      // Render component border
+      ctx.strokeStyle = String(component.properties.borderColor ?? '#e2e8f0');
+      ctx.lineWidth = Number(component.properties.borderWidth ?? 1);
+      ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
 
-    // Render component content based on type
-    switch (component.type) {
-      case 'text':
-        ctx.fillStyle = String(component.properties.color ?? '#000000');
-        ctx.font = `${Number(component.properties.fontSize ?? 16)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
-        ctx.fillText(
-          String(component.properties.text ?? 'Text Component'),
-          bounds.x + 10,
-          bounds.y + bounds.height / 2 + 6
+      // Render component content based on type
+      switch (component.type) {
+        case 'text':
+          ctx.fillStyle = String(component.properties.color ?? '#000000');
+          ctx.font = `${Number(component.properties.fontSize ?? 16)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
+          ctx.fillText(
+            String(component.properties.text ?? 'Text Component'),
+            bounds.x + 10,
+            bounds.y + bounds.height / 2 + 6
+          );
+          break;
+
+        case 'button':
+          // Button background
+          ctx.fillStyle = String(
+            component.properties.backgroundColor ?? '#3b82f6'
+          );
+          ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+          // Button text
+          ctx.fillStyle = String(component.properties.color ?? '#ffffff');
+          ctx.font = `${Number(component.properties.fontSize ?? 14)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
+          ctx.textAlign = 'center';
+          ctx.fillText(
+            String(component.properties.text ?? 'Button'),
+            bounds.x + bounds.width / 2,
+            bounds.y + bounds.height / 2 + 4
+          );
+          ctx.textAlign = 'start';
+          break;
+
+        case 'image':
+          ctx.fillStyle = '#f3f4f6';
+          ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+          ctx.strokeStyle = '#d1d5db';
+          ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
+
+          // Image icon
+          ctx.fillStyle = '#9ca3af';
+          ctx.font = '20px Arial';
+          ctx.textAlign = 'center';
+          ctx.fillText(
+            '🖼️',
+            bounds.x + bounds.width / 2,
+            bounds.y + bounds.height / 2 + 8
+          );
+          ctx.textAlign = 'start';
+          break;
+      }
+
+      // Render selection indicator
+      if (canvasState.selectedComponents.includes(component.id)) {
+        ctx.strokeStyle = '#3b82f6';
+        ctx.lineWidth = 2;
+        ctx.setLineDash([5, 5]);
+        ctx.strokeRect(
+          bounds.x - 2,
+          bounds.y - 2,
+          bounds.width + 4,
+          bounds.height + 4
         );
-        break;
+        ctx.setLineDash([]);
 
-      case 'button':
-        // Button background
-        ctx.fillStyle = String(component.properties.backgroundColor ?? '#3b82f6');
-        ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
+        // Render resize handles
+        const handleSize = 8;
+        ctx.fillStyle = '#3b82f6';
 
-        // Button text
-        ctx.fillStyle = String(component.properties.color ?? '#ffffff');
-        ctx.font = `${Number(component.properties.fontSize ?? 14)}px ${String(component.properties.fontFamily ?? 'Arial')}`;
-        ctx.textAlign = 'center';
-        ctx.fillText(
-          String(component.properties.text ?? 'Button'),
-          bounds.x + bounds.width / 2,
-          bounds.y + bounds.height / 2 + 4
+        // Corner handles
+        ctx.fillRect(
+          bounds.x - handleSize / 2,
+          bounds.y - handleSize / 2,
+          handleSize,
+          handleSize
         );
-        ctx.textAlign = 'start';
-        break;
-
-      case 'image':
-        ctx.fillStyle = '#f3f4f6';
-        ctx.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
-        ctx.strokeStyle = '#d1d5db';
-        ctx.strokeRect(bounds.x, bounds.y, bounds.width, bounds.height);
-
-        // Image icon
-        ctx.fillStyle = '#9ca3af';
-        ctx.font = '20px Arial';
-        ctx.textAlign = 'center';
-        ctx.fillText('🖼️', bounds.x + bounds.width / 2, bounds.y + bounds.height / 2 + 8);
-        ctx.textAlign = 'start';
-        break;
-    }
-
-    // Render selection indicator
-    if (canvasState.selectedComponents.includes(component.id)) {
-      ctx.strokeStyle = '#3b82f6';
-      ctx.lineWidth = 2;
-      ctx.setLineDash([5, 5]);
-      ctx.strokeRect(bounds.x - 2, bounds.y - 2, bounds.width + 4, bounds.height + 4);
-      ctx.setLineDash([]);
-
-      // Render resize handles
-      const handleSize = 8;
-      ctx.fillStyle = '#3b82f6';
-
-      // Corner handles
-      ctx.fillRect(bounds.x - handleSize / 2, bounds.y - handleSize / 2, handleSize, handleSize);
-      ctx.fillRect(bounds.x + bounds.width - handleSize / 2, bounds.y - handleSize / 2, handleSize, handleSize);
-      ctx.fillRect(bounds.x - handleSize / 2, bounds.y + bounds.height - handleSize / 2, handleSize, handleSize);
-      ctx.fillRect(bounds.x + bounds.width - handleSize / 2, bounds.y + bounds.height - handleSize / 2, handleSize, handleSize);
-    }
-  }, [canvasState.selectedComponents]);
+        ctx.fillRect(
+          bounds.x + bounds.width - handleSize / 2,
+          bounds.y - handleSize / 2,
+          handleSize,
+          handleSize
+        );
+        ctx.fillRect(
+          bounds.x - handleSize / 2,
+          bounds.y + bounds.height - handleSize / 2,
+          handleSize,
+          handleSize
+        );
+        ctx.fillRect(
+          bounds.x + bounds.width - handleSize / 2,
+          bounds.y + bounds.height - handleSize / 2,
+          handleSize,
+          handleSize
+        );
+      }
+    },
+    [canvasState.selectedComponents]
+  );
 
   const renderCanvas = useCallback(() => {
     const ctx = ctxRef.current;
@@ -170,8 +217,8 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
 
     // Apply pan and zoom transformations
     ctx.save();
-    ctx.translate(canvasState.pan.x, canvasState.pan.y);
-    ctx.scale(canvasState.zoom, canvasState.zoom);
+    ctx.translate(pan.x, pan.y);
+    ctx.scale(zoom, zoom);
 
     // Render grid
     ctx.strokeStyle = theme === 'dark' ? '#374151' : '#f1f5f9';
@@ -193,129 +240,173 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
     }
 
     // Render components
-    components.forEach(component => {
+    components.forEach((component) => {
       renderComponent(component);
     });
 
     ctx.restore();
-  }, [canvasState.pan, canvasState.zoom, components, renderComponent, theme]);
+  }, [pan, zoom, components, renderComponent, theme]);
 
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    switch (e.key) {
-      case 'Delete':
-      case 'Backspace':
-        setComponents(prev => prev.filter(c => !canvasState.selectedComponents.includes(c.id)));
-        setCanvasState(prev => ({ ...prev, selectedComponents: [] }));
-        break;
-      case 'Escape':
-        setCanvasState(prev => ({ ...prev, selectedComponents: [] }));
-        break;
-      case 'a':
-        if (e.ctrlKey || e.metaKey) {
-          e.preventDefault();
-          setCanvasState(prev => ({ ...prev, selectedComponents: components.map(c => c.id) }));
-        }
-        break;
-    }
-  }, [canvasState.selectedComponents, components]);
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'Delete':
+        case 'Backspace':
+          dispatch(
+            setComponents(
+              components.filter(
+                (c) => !canvasState.selectedComponents.includes(c.id)
+              )
+            )
+          );
+          setCanvasState((prev) => ({ ...prev, selectedComponents: [] }));
+          break;
+        case 'Escape':
+          setCanvasState((prev) => ({ ...prev, selectedComponents: [] }));
+          break;
+        case 'a':
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault();
+            setCanvasState((prev) => ({
+              ...prev,
+              selectedComponents: components.map((c) => c.id)
+            }));
+          }
+          break;
+        case 'z':
+          if (e.ctrlKey || e.metaKey) {
+            e.preventDefault();
+            if (e.shiftKey) {
+              handleRedo();
+            } else {
+              handleUndo();
+            }
+          }
+          break;
+      }
+    },
+    [
+      canvasState.selectedComponents,
+      components,
+      handleUndo,
+      handleRedo,
+      dispatch
+    ]
+  );
 
-  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
 
-    const rect = canvas.getBoundingClientRect();
-    const x = (e.clientX - rect.left - canvasState.pan.x) / canvasState.zoom;
-    const y = (e.clientY - rect.top - canvasState.pan.y) / canvasState.zoom;
+      const rect = canvas.getBoundingClientRect();
+      const x = (e.clientX - rect.left - pan.x) / zoom;
+      const y = (e.clientY - rect.top - pan.y) / zoom;
 
-    // Check if clicking on a component
-    const clickedComponent = components.find(component =>
-      x >= component.bounds.x &&
-      x <= component.bounds.x + component.bounds.width &&
-      y >= component.bounds.y &&
-      y <= component.bounds.y + component.bounds.height
-    );
+      // Check if clicking on a component
+      const clickedComponent = components.find(
+        (component) =>
+          x >= component.bounds.x &&
+          x <= component.bounds.x + component.bounds.width &&
+          y >= component.bounds.y &&
+          y <= component.bounds.y + component.bounds.height
+      );
 
-    if (clickedComponent) {
-      setCanvasState(prev => ({
-        ...prev,
-        selectedComponents: e.shiftKey
-          ? [...prev.selectedComponents, clickedComponent.id]
-          : [clickedComponent.id]
-      }));
-      setIsDragging(true);
-    } else {
-      setCanvasState(prev => ({ ...prev, selectedComponents: [] }));
-    }
-  }, [canvasState.pan, canvasState.zoom, components]);
+      if (clickedComponent) {
+        setCanvasState((prev) => ({
+          ...prev,
+          selectedComponents: e.shiftKey
+            ? [...prev.selectedComponents, clickedComponent.id]
+            : [clickedComponent.id]
+        }));
+        setIsDragging(true);
+      } else {
+        setCanvasState((prev) => ({ ...prev, selectedComponents: [] }));
+      }
+    },
+    [pan, zoom, components]
+  );
 
-  const handleMouseMove = useCallback((_e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!isDragging) return;
+  const handleMouseMove = useCallback(
+    (_e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!isDragging) return;
 
-    // Handle dragging logic here
-    // This would update component positions based on mouse movement
-  }, [isDragging]);
+      // Handle dragging logic here
+      // This would update component positions based on mouse movement
+    },
+    [isDragging]
+  );
 
   const handleMouseUp = useCallback(() => {
     setIsDragging(false);
   }, []);
 
-  const handleTouchStart = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    touchStartTimeRef.current = Date.now();
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      touchStartTimeRef.current = Date.now();
 
-    // Handle multi-touch gestures
-    if (e.touches.length === 2) {
-      const touch1 = e.touches[0];
-      const touch2 = e.touches[1];
+      // Handle multi-touch gestures
+      if (e.touches.length === 2) {
+        const touch1 = e.touches[0];
+        const touch2 = e.touches[1];
 
-      const distance = Math.sqrt(
-        Math.pow(touch2.clientX - touch1.clientX, 2) +
-        Math.pow(touch2.clientY - touch1.clientY, 2)
-      );
+        const distance = Math.sqrt(
+          Math.pow(touch2.clientX - touch1.clientX, 2) +
+            Math.pow(touch2.clientY - touch1.clientY, 2)
+        );
 
-      setLastTouch({
-        startDistance: distance,
-        startZoom: canvasState.zoom,
-      });
-    }
-
-    // Long press detection
-    longPressTimerRef.current = window.setTimeout(() => {
-      // Handle long press (context menu, etc.)
-      if ('vibrate' in navigator) {
-        navigator.vibrate(50);
+        setLastTouch({
+          startDistance: distance,
+          startZoom: zoom
+        });
       }
-    }, 500);
-  }, [canvasState.zoom]);
 
-  const handleTouchMove = useCallback((e: React.TouchEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
+      // Long press detection
+      longPressTimerRef.current = window.setTimeout(() => {
+        // Handle long press (context menu, etc.)
+        if ('vibrate' in navigator) {
+          navigator.vibrate(50);
+        }
+      }, 500);
+    },
+    [zoom]
+  );
 
-    if (
-      e.touches.length === 2 &&
-      lastTouch?.startDistance !== undefined &&
-      lastTouch?.startZoom !== undefined
-    ) {
-      // Handle pinch-to-zoom
-      const touch1 = e.touches[0];
-      const touch2 = e.touches[1];
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
 
-      const distance = Math.sqrt(
-        Math.pow(touch2.clientX - touch1.clientX, 2) +
-        Math.pow(touch2.clientY - touch1.clientY, 2)
-      );
+      if (
+        e.touches.length === 2 &&
+        lastTouch?.startDistance !== undefined &&
+        lastTouch?.startZoom !== undefined
+      ) {
+        // Handle pinch-to-zoom
+        const touch1 = e.touches[0];
+        const touch2 = e.touches[1];
 
-      const scale = distance / lastTouch.startDistance!;
-      const newZoom = Math.max(0.1, Math.min(5, lastTouch.startZoom! * scale));
+        const distance = Math.sqrt(
+          Math.pow(touch2.clientX - touch1.clientX, 2) +
+            Math.pow(touch2.clientY - touch1.clientY, 2)
+        );
 
-      setCanvasState(prev => ({ ...prev, zoom: newZoom }));
-    } else if (e.touches.length === 1) {
-      // Handle single-touch pan
-      const canvas = canvasRef.current;
-      if (!canvas) return;
+        const scale = distance / lastTouch.startDistance!;
+        const newZoom = Math.max(
+          0.1,
+          Math.min(5, lastTouch.startZoom! * scale)
+        );
 
-      canvas.getBoundingClientRect();
-    }
-  }, [lastTouch]);
+        dispatch(setZoom(newZoom));
+      } else if (e.touches.length === 1) {
+        // Handle single-touch pan
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        canvas.getBoundingClientRect();
+      }
+    },
+    [lastTouch, dispatch]
+  );
 
   const handleTouchEnd = useCallback(() => {
     if (longPressTimerRef.current) {
@@ -344,7 +435,6 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
-
 
   return (
     <div
@@ -392,7 +482,7 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
         }}
       >
         <button
-          onClick={() => setCanvasState(prev => ({ ...prev, zoom: Math.max(0.1, prev.zoom - 0.1) }))}
+          onClick={() => dispatch(setZoom(Math.max(0.1, zoom - 0.1)))}
           style={{
             padding: '8px 12px',
             border: 'none',
@@ -412,10 +502,10 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
             fontSize: '14px'
           }}
         >
-          {Math.round(canvasState.zoom * 100)}%
+          {Math.round(zoom * 100)}%
         </span>
         <button
-          onClick={() => setCanvasState(prev => ({ ...prev, zoom: Math.min(5, prev.zoom + 0.1) }))}
+          onClick={() => dispatch(setZoom(Math.min(5, zoom + 0.1)))}
           style={{
             padding: '8px 12px',
             border: 'none',
@@ -429,7 +519,10 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({ theme, 'aria-label':
           <ZoomIn aria-hidden="true" size="S" />
         </button>
         <button
-          onClick={() => setCanvasState(prev => ({ ...prev, zoom: 1, pan: { x: 0, y: 0 } }))}
+          onClick={() => {
+            dispatch(setZoom(1));
+            dispatch(setPan({ x: 0, y: 0 }));
+          }}
           style={{
             padding: '8px 12px',
             border: 'none',

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { EditorTheme } from '../../types/editor-types';
 import { Flex, ButtonGroup, Button } from '@adobe/react-spectrum';
 import Add from '@spectrum-icons/workflow/Add';
@@ -11,6 +11,8 @@ import Moon from '@spectrum-icons/workflow/Moon';
 import Light from '@spectrum-icons/workflow/Light';
 import { useMessageFormatter } from '@react-aria/i18n';
 import messages from '../../i18n/toolbarMessages';
+import { useAppDispatch } from '../../store';
+import { ActionCreators } from 'redux-undo';
 
 interface EditorToolbarProps {
   theme: EditorTheme;
@@ -32,17 +34,14 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
   onThemeChange
 }) => {
   const formatMessage = useMessageFormatter(messages);
-  const [canUndo] = useState(false);
-  const [canRedo] = useState(false);
+  const dispatch = useAppDispatch();
 
   const handleUndo = () => {
-    // Dispatch undo event or call undo handler
-    console.log('Undo action');
+    dispatch(ActionCreators.undo());
   };
 
   const handleRedo = () => {
-    // Dispatch redo event or call redo handler
-    console.log('Redo action');
+    dispatch(ActionCreators.redo());
   };
 
   const handleNew = () => {
@@ -94,16 +93,32 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
         justifyContent="space-between"
       >
         <ButtonGroup>
-          <Button variant="primary" onPress={handleNew} aria-label={formatMessage('new')}>
+          <Button
+            variant="primary"
+            onPress={handleNew}
+            aria-label={formatMessage('new')}
+          >
             <Add aria-hidden="true" size="S" />
           </Button>
-          <Button variant="primary" onPress={handleSave} aria-label={formatMessage('save')}>
+          <Button
+            variant="primary"
+            onPress={handleSave}
+            aria-label={formatMessage('save')}
+          >
             <SaveFloppy aria-hidden="true" size="S" />
           </Button>
-          <Button variant="primary" onPress={handleLoad} aria-label={formatMessage('load')}>
+          <Button
+            variant="primary"
+            onPress={handleLoad}
+            aria-label={formatMessage('load')}
+          >
             <OpenIn aria-hidden="true" size="S" />
           </Button>
-          <Button variant="primary" onPress={handleExport} aria-label={formatMessage('export')}>
+          <Button
+            variant="primary"
+            onPress={handleExport}
+            aria-label={formatMessage('export')}
+          >
             <ExportIcon aria-hidden="true" size="S" />
           </Button>
         </ButtonGroup>
@@ -112,7 +127,6 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
           <Button
             variant="secondary"
             onPress={handleUndo}
-            isDisabled={!canUndo}
             aria-label={formatMessage('undo')}
           >
             <UndoIcon aria-hidden="true" size="S" />
@@ -120,13 +134,11 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
           <Button
             variant="secondary"
             onPress={handleRedo}
-            isDisabled={!canRedo}
             aria-label={formatMessage('redo')}
           >
             <RedoIcon aria-hidden="true" size="S" />
           </Button>
         </ButtonGroup>
-
 
         <ButtonGroup>
           <Button

--- a/src/store/canvasSlice.ts
+++ b/src/store/canvasSlice.ts
@@ -1,0 +1,88 @@
+import { AnyAction } from 'redux';
+import undoable from 'redux-undo';
+import type { BaseComponent } from '../types/component-base';
+import type { Point } from '../types/editor-types';
+
+export interface CanvasState {
+  components: BaseComponent[];
+  zoom: number;
+  pan: Point;
+}
+
+const initialState: CanvasState = {
+  components: [],
+  zoom: 1,
+  pan: { x: 0, y: 0 }
+};
+
+export const setComponents = (components: BaseComponent[]) => ({
+  type: 'canvas/set' as const,
+  payload: components
+});
+
+export const addComponent = (component: BaseComponent) => ({
+  type: 'canvas/add' as const,
+  payload: component
+});
+
+export const removeComponent = (id: string) => ({
+  type: 'canvas/remove' as const,
+  payload: id
+});
+
+export const updateComponent = (component: BaseComponent) => ({
+  type: 'canvas/update' as const,
+  payload: component
+});
+
+export const setZoom = (zoom: number) => ({
+  type: 'canvas/setZoom' as const,
+  payload: zoom
+});
+
+export const setPan = (pan: Point) => ({
+  type: 'canvas/setPan' as const,
+  payload: pan
+});
+
+export type CanvasActions =
+  | ReturnType<typeof setComponents>
+  | ReturnType<typeof addComponent>
+  | ReturnType<typeof removeComponent>
+  | ReturnType<typeof updateComponent>
+  | ReturnType<typeof setZoom>
+  | ReturnType<typeof setPan>;
+
+const reducer = (
+  state: CanvasState = initialState,
+  action: CanvasActions
+): CanvasState => {
+  switch (action.type) {
+    case 'canvas/set':
+      return { ...state, components: action.payload };
+    case 'canvas/add':
+      return { ...state, components: [...state.components, action.payload] };
+    case 'canvas/remove':
+      return {
+        ...state,
+        components: state.components.filter((c) => c.id !== action.payload)
+      };
+    case 'canvas/update':
+      return {
+        ...state,
+        components: state.components.map((c) =>
+          c.id === action.payload.id ? action.payload : c
+        )
+      };
+    case 'canvas/setZoom':
+      return { ...state, zoom: action.payload };
+    case 'canvas/setPan':
+      return { ...state, pan: action.payload };
+    default:
+      return state;
+  }
+};
+
+export const canvasReducer = undoable<CanvasState, AnyAction>(
+  reducer as (state: CanvasState | undefined, action: AnyAction) => CanvasState
+);

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export * from './store';
+export * from './canvasSlice';
+export * from './hooks';

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { canvasReducer } from './canvasSlice';
+
+export const store = configureStore({
+  reducer: {
+    canvas: canvasReducer
+  }
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/types/editor-types.ts
+++ b/src/types/editor-types.ts
@@ -1,4 +1,8 @@
-import type { BaseComponent, ComponentProperties, ComponentPropertyValue } from "./component-base";
+import type {
+  BaseComponent,
+  ComponentProperties,
+  ComponentPropertyValue
+} from './component-base';
 export type EditorTheme = 'light' | 'dark';
 
 export interface Point {
@@ -11,7 +15,7 @@ export interface Size {
   height: number;
 }
 
-export interface Bounds extends Point, Size { }
+export interface Bounds extends Point, Size {}
 
 export interface EditorComponent {
   id: string;
@@ -60,12 +64,8 @@ export interface TouchGesture {
 }
 
 export interface CanvasState {
-  zoom: number;
-  pan: Point;
   selectedComponents: string[];
   clipboard: BaseComponent[];
-  history: BaseComponent[][];
-  historyIndex: number;
 }
 
 export interface AccessibilityOptions {


### PR DESCRIPTION
## Summary
- extend canvas slice with `zoom` and `pan`
- dispatch `setZoom` and `setPan` from `EditorCanvas`
- keep selected component state local but read zoom/pan from Redux
- document Redux history in README
- ignore workflow file for Prettier
- revert unrelated workflow changes

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6854a0bf898c8331a43b3234c86838fc