### PR TITLE
Add canvas size selector

### DIFF
--- a/__tests__/editor-canvas.test.tsx
+++ b/__tests__/editor-canvas.test.tsx
@@ -7,7 +7,7 @@ import { store } from '../src/store';
 test('renders editor canvas', () => {
   render(
     <Provider store={store}>
-      <EditorCanvas theme="light" />
+      <EditorCanvas theme="light" canvasSize="infinite" />
     </Provider>
   );
   const canvas = screen.getByRole('img', { name: /design canvas/i });

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -12,7 +12,12 @@ test('renders toolbar', () => {
     <ReduxProvider store={store}>
       <I18nProvider locale="en-US">
         <Provider theme={defaultTheme} colorScheme="light">
-          <EditorToolbar theme="light" onThemeChange={() => {}} />
+          <EditorToolbar
+            theme="light"
+            onThemeChange={() => {}}
+            canvasSize="infinite"
+            onCanvasSizeChange={() => {}}
+          />
         </Provider>
       </I18nProvider>
     </ReduxProvider>
@@ -28,7 +33,12 @@ test('dispatches save event', async () => {
     <ReduxProvider store={store}>
       <I18nProvider locale="en-US">
         <Provider theme={defaultTheme} colorScheme="light">
-          <EditorToolbar theme="light" onThemeChange={() => {}} />
+          <EditorToolbar
+            theme="light"
+            onThemeChange={() => {}}
+            canvasSize="infinite"
+            onCanvasSizeChange={() => {}}
+          />
         </Provider>
       </I18nProvider>
     </ReduxProvider>
@@ -36,4 +46,22 @@ test('dispatches save event', async () => {
   await userEvent.click(screen.getByRole('button', { name: /save/i }));
   expect(listener).toHaveBeenCalled();
   window.removeEventListener('editor-save', listener);
+});
+
+test('renders canvas size selector', () => {
+  render(
+    <ReduxProvider store={store}>
+      <I18nProvider locale="en-US">
+        <Provider theme={defaultTheme} colorScheme="light">
+          <EditorToolbar
+            theme="light"
+            onThemeChange={() => {}}
+            canvasSize="infinite"
+            onCanvasSizeChange={() => {}}
+          />
+        </Provider>
+      </I18nProvider>
+    </ReduxProvider>
+  );
+  expect(screen.getByLabelText(/canvas size/i)).toBeInTheDocument();
 });

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { EditorTheme } from '../../types/editor-types';
+import { EditorTheme, CanvasSize } from '../../types/editor-types';
 import { EditorToolbar } from '../toolbar/component';
 import { ComponentPalette } from '../component-palette/component';
 import { EditorCanvas } from '../editor-canvas/component';
@@ -19,6 +19,7 @@ export const EditorApp: React.FC = () => {
   const [theme, setTheme] = useState<EditorTheme>('light');
   const [showPalette, setShowPalette] = useState(true);
   const [showControl, setShowControl] = useState(true);
+  const [canvasSize, setCanvasSize] = useState<CanvasSize>('infinite');
 
   const handleThemeChange = useCallback(
     (e: MediaQueryListEvent | MediaQueryList) => {
@@ -66,7 +67,12 @@ export const EditorApp: React.FC = () => {
                 background: theme === 'dark' ? '#374151' : 'white'
               }}
             >
-              <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
+              <EditorToolbar
+                theme={theme}
+                onThemeChange={handleThemeToggle}
+                canvasSize={canvasSize}
+                onCanvasSizeChange={setCanvasSize}
+              />
             </div>
             <div
               style={{
@@ -132,7 +138,11 @@ export const EditorApp: React.FC = () => {
                     «
                   </button>
                 )}
-                <EditorCanvas theme={theme} aria-label="Design Canvas" />
+                <EditorCanvas
+                  theme={theme}
+                  canvasSize={canvasSize}
+                  aria-label="Design Canvas"
+                />
               </div>
               {showControl && (
                 <div

--- a/src/components/editor-canvas/README.md
+++ b/src/components/editor-canvas/README.md
@@ -25,18 +25,19 @@ import { EditorCanvas } from './editor-canvas/component.js';
 
 ## Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `theme` | `EditorTheme` | `'light'` | Visual theme (light/dark) |
+| Property     | Type          | Default      | Description                       |
+| ------------ | ------------- | ------------ | --------------------------------- |
+| `theme`      | `EditorTheme` | `'light'`    | Visual theme (light/dark)         |
+| `canvasSize` | `CanvasSize`  | `'infinite'` | Canvas dimensions or `'infinite'` |
 
 ## Events
 
-| Event | Detail | Description |
-|-------|--------|-------------|
-| `selection-change` | `{selectedComponents: string[]}` | Fired when component selection changes |
-| `context-menu` | `{point: Point, components: EditorComponent}` | Fired on long press/right click |
-| `component-move` | `{component: EditorComponent, position: Point}` | Fired when component is moved |
-| `component-resize` | `{component: EditorComponent, bounds: Bounds}` | Fired when component is resized |
+| Event              | Detail                                          | Description                            |
+| ------------------ | ----------------------------------------------- | -------------------------------------- |
+| `selection-change` | `{selectedComponents: string[]}`                | Fired when component selection changes |
+| `context-menu`     | `{point: Point, components: EditorComponent}`   | Fired on long press/right click        |
+| `component-move`   | `{component: EditorComponent, position: Point}` | Fired when component is moved          |
+| `component-resize` | `{component: EditorComponent, bounds: Bounds}`  | Fired when component is resized        |
 
 ## Keyboard Shortcuts
 

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import { EditorTheme, CanvasState } from '../../types/editor-types';
+import { EditorTheme, CanvasState, CanvasSize } from '../../types/editor-types';
 import ZoomOut from '@spectrum-icons/workflow/ZoomOut';
 import ZoomIn from '@spectrum-icons/workflow/ZoomIn';
 import Refresh from '@spectrum-icons/workflow/Refresh';
@@ -15,6 +15,7 @@ interface PinchState {
 
 interface EditorCanvasProps {
   theme: EditorTheme;
+  canvasSize: CanvasSize;
   'aria-label'?: string;
 }
 
@@ -29,6 +30,7 @@ interface EditorCanvasProps {
  */
 export const EditorCanvas: React.FC<EditorCanvasProps> = ({
   theme,
+  canvasSize,
   'aria-label': ariaLabel
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -441,8 +443,8 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({
       ref={containerRef}
       className="canvas-container"
       style={{
-        width: '100%',
-        height: '100%',
+        width: canvasSize === 'infinite' ? '100%' : `${canvasSize.width}px`,
+        height: canvasSize === 'infinite' ? '100%' : `${canvasSize.height}px`,
         position: 'relative',
         overflow: 'hidden',
         background: theme === 'dark' ? '#1e293b' : '#f8fafc',

--- a/src/components/toolbar/README.md
+++ b/src/components/toolbar/README.md
@@ -23,9 +23,10 @@ import { EditorToolbar } from './toolbar/component.js';
 
 ## Properties
 
-| Property | Type          | Default   | Description               |
-| -------- | ------------- | --------- | ------------------------- |
-| `theme`  | `EditorTheme` | `'light'` | Visual theme (light/dark) |
+| Property     | Type          | Default      | Description                             |
+| ------------ | ------------- | ------------ | --------------------------------------- |
+| `theme`      | `EditorTheme` | `'light'`    | Visual theme (light/dark)               |
+| `canvasSize` | `CanvasSize`  | `'infinite'` | Selected canvas size or infinite canvas |
 
 ## Events
 

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EditorTheme } from '../../types/editor-types';
+import { EditorTheme, CanvasSize } from '../../types/editor-types';
 import { Flex, ButtonGroup, Button } from '@adobe/react-spectrum';
 import Add from '@spectrum-icons/workflow/Add';
 import SaveFloppy from '@spectrum-icons/workflow/SaveFloppy';
@@ -16,6 +16,8 @@ import { ActionCreators } from 'redux-undo';
 interface EditorToolbarProps {
   theme: EditorTheme;
   onThemeChange: (theme: EditorTheme) => void;
+  canvasSize: CanvasSize;
+  onCanvasSizeChange: (size: CanvasSize) => void;
 }
 
 /**
@@ -30,7 +32,9 @@ interface EditorToolbarProps {
  */
 export const EditorToolbar: React.FC<EditorToolbarProps> = ({
   theme,
-  onThemeChange
+  onThemeChange,
+  canvasSize,
+  onCanvasSizeChange
 }) => {
   const formatMessage = useMessageFormatter(messages);
   const dispatch = useAppDispatch();
@@ -150,6 +154,30 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             )}
           </Button>
         </ButtonGroup>
+
+        <select
+          aria-label={formatMessage('canvasSize')}
+          value={
+            canvasSize === 'infinite'
+              ? 'infinite'
+              : `${canvasSize.width}x${canvasSize.height}`
+          }
+          onChange={(e) => {
+            const value = e.target.value;
+            if (value === 'infinite') {
+              onCanvasSizeChange('infinite');
+            } else {
+              const [w, h] = value.split('x').map(Number);
+              onCanvasSizeChange({ width: w, height: h });
+            }
+          }}
+          style={{ padding: '4px 8px', borderRadius: '4px' }}
+        >
+          <option value="infinite">{formatMessage('infinite')}</option>
+          <option value="360x640">{formatMessage('mobile')}</option>
+          <option value="768x1024">{formatMessage('tablet')}</option>
+          <option value="1920x1080">{formatMessage('desktop')}</option>
+        </select>
       </Flex>
     </div>
   );

--- a/src/i18n/toolbarMessages.ts
+++ b/src/i18n/toolbarMessages.ts
@@ -10,7 +10,12 @@ export const toolbarMessages = {
     zoomIn: 'Zoom in',
     resetZoom: 'Reset zoom',
     dark: 'Dark',
-    light: 'Light'
+    light: 'Light',
+    canvasSize: 'Canvas size',
+    infinite: 'Infinite',
+    mobile: 'Mobile',
+    tablet: 'Tablet',
+    desktop: 'Desktop'
   },
   'es-ES': {
     toolbar: 'Barra de herramientas',
@@ -23,7 +28,12 @@ export const toolbarMessages = {
     zoomIn: 'Acercar',
     resetZoom: 'Restablecer zoom',
     dark: 'Oscuro',
-    light: 'Claro'
+    light: 'Claro',
+    canvasSize: 'Tamaño del lienzo',
+    infinite: 'Infinito',
+    mobile: 'Móvil',
+    tablet: 'Tableta',
+    desktop: 'Escritorio'
   }
 };
 export default toolbarMessages;

--- a/src/types/editor-types.ts
+++ b/src/types/editor-types.ts
@@ -76,3 +76,10 @@ export interface AccessibilityOptions {
   screenReader: boolean;
   keyboardNavigation: boolean;
 }
+
+export type CanvasSize =
+  | 'infinite'
+  | {
+      width: number;
+      height: number;
+    };


### PR DESCRIPTION
## Summary
- support optional canvas size via new `CanvasSize` type
- expose `canvasSize` prop in `EditorCanvas` and `EditorToolbar`
- add dropdown selector in toolbar
- document the new properties
- update tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6854e25167ec8331952fc3a79f2b1a05