### PR TITLE
Add share link feature

### DIFF
--- a/__tests__/share.test.ts
+++ b/__tests__/share.test.ts
@@ -1,0 +1,8 @@
+import { encodeComponents, decodeComponents } from '../src/utils/share';
+
+test('encode and decode roundtrip', () => {
+  const components = [{ id: '1', type: 'text' }];
+  const encoded = encodeComponents(components);
+  const decoded = decodeComponents(encoded) as typeof components;
+  expect(decoded).toEqual(components);
+});

--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -37,3 +37,20 @@ test('dispatches save event', async () => {
   expect(listener).toHaveBeenCalled();
   window.removeEventListener('editor-save', listener);
 });
+
+test('dispatches share event', async () => {
+  const listener = jest.fn();
+  window.addEventListener('editor-share', listener);
+  render(
+    <ReduxProvider store={store}>
+      <I18nProvider locale="en-US">
+        <Provider theme={defaultTheme} colorScheme="light">
+          <EditorToolbar theme="light" onThemeChange={() => {}} />
+        </Provider>
+      </I18nProvider>
+    </ReduxProvider>
+  );
+  await userEvent.click(screen.getByRole('button', { name: /share/i }));
+  expect(listener).toHaveBeenCalled();
+  window.removeEventListener('editor-share', listener);
+});

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -9,8 +9,10 @@ import {
   defaultTheme
 } from '@adobe/react-spectrum';
 import { Provider as ReduxProvider } from 'react-redux';
-import { store } from '../../store';
+import { store, setComponents } from '../../store';
 import { I18nProvider } from '@react-aria/i18n';
+import { decodeComponents } from '../../utils/share';
+import type { BaseComponent } from '../../types/component-base';
 
 /**
  * Main editor application using a simple flex layout
@@ -35,6 +37,17 @@ export const EditorApp: React.FC = () => {
       mediaQuery.removeEventListener('change', handleThemeChange);
     };
   }, [handleThemeChange]);
+
+  useEffect(() => {
+    const params = new window.URLSearchParams(window.location.search);
+    const state = params.get('state');
+    if (state) {
+      const components = decodeComponents(state);
+      if (Array.isArray(components)) {
+        store.dispatch(setComponents(components as BaseComponent[]));
+      }
+    }
+  }, []);
 
   const borderColor = theme === 'dark' ? '#374151' : '#e2e8f0';
 

--- a/src/components/toolbar/README.md
+++ b/src/components/toolbar/README.md
@@ -5,6 +5,7 @@ A comprehensive toolbar component providing file operations, editing controls, a
 ## Features
 
 - **File Operations**: New, Save, Open functionality
+- **Share Links**: Generate URL containing the current canvas state
 - **Editing Controls**: Undo/redo with visual feedback
 - **Zoom Controls**: Zoom in/out/reset with live percentage display
 - **Theme Toggle**: Switch between light and dark themes
@@ -34,6 +35,7 @@ import { EditorToolbar } from './toolbar/component.js';
 | `editor-new`   | `{}`                   | Fired when new document is requested |
 | `editor-save`  | `{canvas: object}`     | Fired when save is requested         |
 | `editor-open`  | `{canvas: object}`     | Fired when a file is opened          |
+| `editor-share` | `{url: string}`        | Fired when a share link is generated |
 | `editor-undo`  | `{}`                   | Fired when undo is requested         |
 | `editor-redo`  | `{}`                   | Fired when redo is requested         |
 | `editor-zoom`  | `{zoom: number}`       | Fired when zoom level changes        |

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -4,6 +4,7 @@ import { Flex, ButtonGroup, Button } from '@adobe/react-spectrum';
 import Add from '@spectrum-icons/workflow/Add';
 import SaveFloppy from '@spectrum-icons/workflow/SaveFloppy';
 import OpenIn from '@spectrum-icons/workflow/OpenIn';
+import Share from '@spectrum-icons/workflow/Share';
 import UndoIcon from '@spectrum-icons/workflow/Undo';
 import RedoIcon from '@spectrum-icons/workflow/Redo';
 import Moon from '@spectrum-icons/workflow/Moon';
@@ -12,6 +13,7 @@ import { useMessageFormatter } from '@react-aria/i18n';
 import messages from '../../i18n/toolbarMessages';
 import { useAppDispatch, store } from '../../store';
 import { ActionCreators } from 'redux-undo';
+import { encodeComponents } from '../../utils/share';
 
 interface EditorToolbarProps {
   theme: EditorTheme;
@@ -82,6 +84,23 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
     input.click();
   };
 
+  const handleShare = async () => {
+    const components = store.getState().canvas.present.components;
+    const encoded = encodeComponents(components);
+    const url = new URL(window.location.href);
+    url.searchParams.set('state', encoded);
+    try {
+      await navigator.clipboard.writeText(url.toString());
+    } catch (_err) {
+      window.prompt('Share this link:', url.toString());
+    }
+    window.dispatchEvent(
+      new window.CustomEvent('editor-share', {
+        detail: { url: url.toString() }
+      })
+    );
+  };
+
   const toggleTheme = () => {
     onThemeChange(theme === 'light' ? 'dark' : 'light');
   };
@@ -115,6 +134,13 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             aria-label={formatMessage('open')}
           >
             <OpenIn aria-hidden="true" size="S" />
+          </Button>
+          <Button
+            variant="primary"
+            onPress={handleShare}
+            aria-label={formatMessage('share')}
+          >
+            <Share aria-hidden="true" size="S" />
           </Button>
         </ButtonGroup>
 

--- a/src/i18n/toolbarMessages.ts
+++ b/src/i18n/toolbarMessages.ts
@@ -9,6 +9,7 @@ export const toolbarMessages = {
     zoomOut: 'Zoom out',
     zoomIn: 'Zoom in',
     resetZoom: 'Reset zoom',
+    share: 'Share',
     dark: 'Dark',
     light: 'Light'
   },
@@ -22,6 +23,7 @@ export const toolbarMessages = {
     zoomOut: 'Alejar',
     zoomIn: 'Acercar',
     resetZoom: 'Restablecer zoom',
+    share: 'Compartir',
     dark: 'Oscuro',
     light: 'Claro'
   }

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,0 +1,20 @@
+export function encodeComponents(components: unknown[]): string {
+  const json = JSON.stringify(components);
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis.btoa(unescape(encodeURIComponent(json)));
+  }
+  return Buffer.from(json, 'utf-8').toString('base64');
+}
+
+export function decodeComponents(value: string): unknown[] | null {
+  try {
+    const json =
+      typeof globalThis.atob === 'function'
+        ? decodeURIComponent(escape(globalThis.atob(value)))
+        : Buffer.from(value, 'base64').toString('utf-8');
+    return JSON.parse(json);
+  } catch (_err) {
+    console.warn('Failed to decode shared state');
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- enable link encoding and decoding of canvas components
- expose share button in toolbar and document it
- decode shared state on application load
- test share utilities and event

## Testing
- `npx prettier -w __tests__/toolbar.test.tsx __tests__/share.test.ts src/components/editor-app/component.tsx src/components/toolbar/README.md src/components/toolbar/component.tsx src/i18n/toolbarMessages.ts src/utils/share.ts`
- `npx eslint __tests__/toolbar.test.tsx __tests__/share.test.ts src/components/editor-app/component.tsx src/components/toolbar/README.md src/components/toolbar/component.tsx src/i18n/toolbarMessages.ts src/utils/share.ts`
- `npm run type-check`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6854e1dc0f0483318ae34ef311ed5fa9