### PR TITLE
feat: infinite canvas resolution modes

### DIFF
--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { EditorTheme } from '../../types/editor-types';
+import type { Resolution } from '../../types/editor-types';
 import { EditorToolbar } from '../toolbar/component';
 import { ComponentPalette } from '../component-palette/component';
 import { EditorCanvas } from '../editor-canvas/component';
@@ -21,6 +22,9 @@ export const EditorApp: React.FC = () => {
   const [theme, setTheme] = useState<EditorTheme>('light');
   const [showPalette, setShowPalette] = useState(true);
   const [showControl, setShowControl] = useState(true);
+  const [resolution, setResolution] = useState<Resolution | undefined>(
+    undefined
+  );
 
   const handleThemeChange = useCallback(
     (e: MediaQueryListEvent | MediaQueryList) => {
@@ -79,7 +83,12 @@ export const EditorApp: React.FC = () => {
                 background: theme === 'dark' ? '#374151' : 'white'
               }}
             >
-              <EditorToolbar theme={theme} onThemeChange={handleThemeToggle} />
+              <EditorToolbar
+                theme={theme}
+                onThemeChange={handleThemeToggle}
+                resolution={resolution}
+                onResolutionChange={setResolution}
+              />
             </div>
             <div
               style={{
@@ -145,7 +154,11 @@ export const EditorApp: React.FC = () => {
                     «
                   </button>
                 )}
-                <EditorCanvas theme={theme} aria-label="Design Canvas" />
+                <EditorCanvas
+                  theme={theme}
+                  resolution={resolution}
+                  aria-label="Design Canvas"
+                />
               </div>
               {showControl && (
                 <div

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -13,8 +13,11 @@ interface PinchState {
   startZoom: number;
 }
 
+import type { Resolution } from '../../types/editor-types';
+
 interface EditorCanvasProps {
   theme: EditorTheme;
+  resolution?: Resolution;
   'aria-label'?: string;
 }
 
@@ -29,6 +32,7 @@ interface EditorCanvasProps {
  */
 export const EditorCanvas: React.FC<EditorCanvasProps> = ({
   theme,
+  resolution,
   'aria-label': ariaLabel
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -224,18 +228,24 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({
     ctx.strokeStyle = theme === 'dark' ? '#374151' : '#f1f5f9';
     ctx.lineWidth = 1;
     const gridSize = 20;
+    const startX =
+      (((-canvasState.pan.x / canvasState.zoom) % gridSize) + gridSize) %
+      gridSize;
+    const startY =
+      (((-canvasState.pan.y / canvasState.zoom) % gridSize) + gridSize) %
+      gridSize;
 
-    for (let x = 0; x < width; x += gridSize) {
+    for (let x = startX; x < width / canvasState.zoom; x += gridSize) {
       ctx.beginPath();
       ctx.moveTo(x, 0);
-      ctx.lineTo(x, height);
+      ctx.lineTo(x, height / canvasState.zoom);
       ctx.stroke();
     }
 
-    for (let y = 0; y < height; y += gridSize) {
+    for (let y = startY; y < height / canvasState.zoom; y += gridSize) {
       ctx.beginPath();
       ctx.moveTo(0, y);
-      ctx.lineTo(width, y);
+      ctx.lineTo(width / canvasState.zoom, y);
       ctx.stroke();
     }
 
@@ -441,8 +451,9 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({
       ref={containerRef}
       className="canvas-container"
       style={{
-        width: '100%',
-        height: '100%',
+        width: resolution ? `${resolution.width}px` : '100%',
+        height: resolution ? `${resolution.height}px` : '100%',
+        margin: resolution ? '0 auto' : undefined,
         position: 'relative',
         overflow: 'hidden',
         background: theme === 'dark' ? '#1e293b' : '#f8fafc',

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EditorTheme } from '../../types/editor-types';
+import { EditorTheme, Resolution } from '../../types/editor-types';
 import { Flex, ButtonGroup, Button } from '@adobe/react-spectrum';
 import Add from '@spectrum-icons/workflow/Add';
 import SaveFloppy from '@spectrum-icons/workflow/SaveFloppy';
@@ -18,6 +18,8 @@ import { encodeComponents } from '../../utils/share';
 interface EditorToolbarProps {
   theme: EditorTheme;
   onThemeChange: (theme: EditorTheme) => void;
+  resolution?: Resolution;
+  onResolutionChange?: (resolution?: Resolution) => void;
 }
 
 /**
@@ -32,10 +34,19 @@ interface EditorToolbarProps {
  */
 export const EditorToolbar: React.FC<EditorToolbarProps> = ({
   theme,
-  onThemeChange
+  onThemeChange,
+  resolution,
+  onResolutionChange
 }) => {
   const formatMessage = useMessageFormatter(messages);
   const dispatch = useAppDispatch();
+
+  const resolutions: { label: string; value?: Resolution }[] = [
+    { label: formatMessage('infinite'), value: undefined },
+    { label: '1024x768', value: { width: 1024, height: 768 } },
+    { label: '1366x768', value: { width: 1366, height: 768 } },
+    { label: '1920x1080', value: { width: 1920, height: 1080 } }
+  ];
 
   const handleUndo = () => {
     dispatch(ActionCreators.undo());
@@ -176,6 +187,52 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             )}
           </Button>
         </ButtonGroup>
+
+        {onResolutionChange && (
+          <select
+            aria-label={formatMessage('resolution')}
+            value={
+              resolution
+                ? `${resolution.width}x${resolution.height}`
+                : 'infinite'
+            }
+            onChange={(e) => {
+              const value = e.target.value;
+              const selected = resolutions.find((r) =>
+                r.value
+                  ? `${r.value.width}x${r.value.height}` === value
+                  : value === 'infinite'
+              );
+              onResolutionChange(selected?.value);
+            }}
+            style={{
+              padding: '8px 12px',
+              border: `1px solid ${theme === 'dark' ? '#6b7280' : '#d1d5db'}`,
+              borderRadius: '6px',
+              background: theme === 'dark' ? '#4b5563' : '#ffffff',
+              color: theme === 'dark' ? '#f8fafc' : '#1e293b',
+              fontSize: '14px'
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = '#3b82f6';
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor =
+                theme === 'dark' ? '#6b7280' : '#d1d5db';
+            }}
+          >
+            {resolutions.map((r) => (
+              <option
+                key={r.label}
+                value={
+                  r.value ? `${r.value.width}x${r.value.height}` : 'infinite'
+                }
+              >
+                {r.label}
+              </option>
+            ))}
+          </select>
+        )}
       </Flex>
     </div>
   );

--- a/src/i18n/toolbarMessages.ts
+++ b/src/i18n/toolbarMessages.ts
@@ -11,7 +11,9 @@ export const toolbarMessages = {
     resetZoom: 'Reset zoom',
     share: 'Share',
     dark: 'Dark',
-    light: 'Light'
+    light: 'Light',
+    resolution: 'Resolution',
+    infinite: 'Infinite Canvas'
   },
   'es-ES': {
     toolbar: 'Barra de herramientas',
@@ -25,7 +27,9 @@ export const toolbarMessages = {
     resetZoom: 'Restablecer zoom',
     share: 'Compartir',
     dark: 'Oscuro',
-    light: 'Claro'
+    light: 'Claro',
+    resolution: 'Resoluci\u00f3n',
+    infinite: 'Lienzo infinito'
   }
 };
 export default toolbarMessages;

--- a/src/types/editor-types.ts
+++ b/src/types/editor-types.ts
@@ -15,6 +15,8 @@ export interface Size {
   height: number;
 }
 
+export type Resolution = Size;
+
 export interface Bounds extends Point, Size {}
 
 export interface EditorComponent {


### PR DESCRIPTION
## Summary
- add `resolution` dropdown in `EditorToolbar`
- pass selected resolution to `EditorCanvas` via `EditorApp`
- support optional fixed canvas size and infinite grid offsets
- document new toolbar i18n strings

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_685560b9ed4c833188aba313495767a0