### PR TITLE
Implement undo and redo events

### DIFF
--- a/__tests__/toolbar.test.tsx
+++ b/__tests__/toolbar.test.tsx
@@ -54,3 +54,37 @@ test('dispatches share event', async () => {
   expect(listener).toHaveBeenCalled();
   window.removeEventListener('editor-share', listener);
 });
+
+test('dispatches undo event', async () => {
+  const listener = jest.fn();
+  window.addEventListener('editor-undo', listener);
+  render(
+    <ReduxProvider store={store}>
+      <I18nProvider locale="en-US">
+        <Provider theme={defaultTheme} colorScheme="light">
+          <EditorToolbar theme="light" onThemeChange={() => {}} />
+        </Provider>
+      </I18nProvider>
+    </ReduxProvider>
+  );
+  await userEvent.click(screen.getByRole('button', { name: /undo/i }));
+  expect(listener).toHaveBeenCalled();
+  window.removeEventListener('editor-undo', listener);
+});
+
+test('dispatches redo event', async () => {
+  const listener = jest.fn();
+  window.addEventListener('editor-redo', listener);
+  render(
+    <ReduxProvider store={store}>
+      <I18nProvider locale="en-US">
+        <Provider theme={defaultTheme} colorScheme="light">
+          <EditorToolbar theme="light" onThemeChange={() => {}} />
+        </Provider>
+      </I18nProvider>
+    </ReduxProvider>
+  );
+  await userEvent.click(screen.getByRole('button', { name: /redo/i }));
+  expect(listener).toHaveBeenCalled();
+  window.removeEventListener('editor-redo', listener);
+});

--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -440,11 +440,18 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({
 
   // Keyboard event listeners
   useEffect(() => {
+    const undoHandler = () => handleUndo();
+    const redoHandler = () => handleRedo();
+
     window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('editor-undo', undoHandler);
+    window.addEventListener('editor-redo', redoHandler);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('editor-undo', undoHandler);
+      window.removeEventListener('editor-redo', redoHandler);
     };
-  }, [handleKeyDown]);
+  }, [handleKeyDown, handleUndo, handleRedo]);
 
   return (
     <div

--- a/src/components/toolbar/component.tsx
+++ b/src/components/toolbar/component.tsx
@@ -50,10 +50,12 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
 
   const handleUndo = () => {
     dispatch(ActionCreators.undo());
+    window.dispatchEvent(new window.CustomEvent('editor-undo'));
   };
 
   const handleRedo = () => {
     dispatch(ActionCreators.redo());
+    window.dispatchEvent(new window.CustomEvent('editor-redo'));
   };
 
   const handleNew = () => {


### PR DESCRIPTION
## Summary
- dispatch `editor-undo` and `editor-redo` events from the toolbar
- listen for these events in the canvas component
- test undo/redo event dispatch

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855670805a08331817a62f50d165746