### PR TITLE
Improve panel toggle design and lint styles

### DIFF
--- a/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
+++ b/.github/workflows/azure-static-web-apps-kind-bush-0dd23160f.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: dist
+          path: .
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+coverage/

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ['stylelint-config-standard', 'stylelint-config-tailwindcss'],
+  rules: {
+    'block-no-empty': [true, { severity: 'warning' }],
+    'no-descending-specificity': null,
+    'keyframes-name-pattern': null,
+    'media-feature-name-value-no-unknown': null
+  }
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "serve": "vite preview --port 3000",
-    "lint": "eslint . --fix",
+    "lint": "eslint . --fix && stylelint \"**/*.css\" --fix",
     "format": "prettier --write .",
     "test": "jest",
     "test:e2e": "playwright test",
@@ -87,7 +87,10 @@
     "workbox-window": "^7.3.0",
     "glob": "^11.0.3",
     "npm": "^11.4.2",
-    "@playwright/test": "^1.53.1"
+    "@playwright/test": "^1.53.1",
+    "stylelint": "^16.21.0",
+    "stylelint-config-standard": "^38.0.0",
+    "stylelint-config-tailwindcss": "^1.0.0"
   },
   "engines": {
     "node": ">=22.0.0",

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -53,8 +53,6 @@ export const EditorApp: React.FC = () => {
     }
   }, []);
 
-  const borderColor = theme === 'dark' ? '#374151' : '#e2e8f0';
-
   const handleThemeToggle = (newTheme: EditorTheme) => {
     setTheme(newTheme);
   };
@@ -64,24 +62,20 @@ export const EditorApp: React.FC = () => {
       <I18nProvider locale={navigator.language}>
         <SpectrumProvider theme={defaultTheme} colorScheme={theme}>
           <div
-            className="editor-container"
+            className={`editor-container flex flex-col w-full h-full ${
+              theme === 'dark'
+                ? 'bg-slate-800 text-slate-100'
+                : 'bg-slate-50 text-slate-900'
+            }`}
             role="application"
             aria-label="React Component Editor"
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              width: '100%',
-              height: '100%',
-              background: theme === 'dark' ? '#1e293b' : '#f8fafc',
-              color: theme === 'dark' ? '#f8fafc' : '#1e293b'
-            }}
           >
             <div
-              style={{
-                height: '60px',
-                borderBottom: `1px solid ${borderColor}`,
-                background: theme === 'dark' ? '#374151' : 'white'
-              }}
+              className={`h-[60px] border-b ${
+                theme === 'dark'
+                  ? 'border-slate-700 bg-slate-700'
+                  : 'border-slate-200 bg-white'
+              }`}
             >
               <EditorToolbar
                 theme={theme}
@@ -90,31 +84,20 @@ export const EditorApp: React.FC = () => {
                 onResolutionChange={setResolution}
               />
             </div>
-            <div
-              style={{
-                display: 'flex',
-                flex: 1,
-                overflow: 'hidden',
-                position: 'relative'
-              }}
-            >
+            <div className="relative flex flex-1 overflow-hidden">
               {showPalette && (
                 <div
-                  style={{
-                    width: '250px',
-                    borderRight: `1px solid ${borderColor}`,
-                    overflow: 'auto',
-                    position: 'relative'
-                  }}
+                  className={`relative w-[250px] overflow-auto border-r ${
+                    theme === 'dark' ? 'border-slate-700' : 'border-slate-200'
+                  }`}
                 >
                   <button
                     onClick={() => setShowPalette(false)}
-                    style={{
-                      position: 'absolute',
-                      top: 4,
-                      right: 4,
-                      zIndex: 10
-                    }}
+                    className={`absolute right-1 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                      theme === 'dark'
+                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                    }`}
                     aria-label="Collapse component palette"
                   >
                     «
@@ -125,16 +108,15 @@ export const EditorApp: React.FC = () => {
                   />
                 </div>
               )}
-              <div style={{ flex: 1, overflow: 'auto', position: 'relative' }}>
+              <div className="relative flex-1 overflow-auto">
                 {!showPalette && (
                   <button
                     onClick={() => setShowPalette(true)}
-                    style={{
-                      position: 'absolute',
-                      left: 0,
-                      top: 4,
-                      zIndex: 10
-                    }}
+                    className={`absolute left-0 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                      theme === 'dark'
+                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                    }`}
                     aria-label="Expand component palette"
                   >
                     »
@@ -143,12 +125,11 @@ export const EditorApp: React.FC = () => {
                 {!showControl && (
                   <button
                     onClick={() => setShowControl(true)}
-                    style={{
-                      position: 'absolute',
-                      right: 0,
-                      top: 4,
-                      zIndex: 10
-                    }}
+                    className={`absolute right-0 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                      theme === 'dark'
+                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                    }`}
                     aria-label="Expand properties panel"
                   >
                     «
@@ -162,21 +143,17 @@ export const EditorApp: React.FC = () => {
               </div>
               {showControl && (
                 <div
-                  style={{
-                    width: '300px',
-                    borderLeft: `1px solid ${borderColor}`,
-                    overflow: 'auto',
-                    position: 'relative'
-                  }}
+                  className={`relative w-[300px] overflow-auto border-l ${
+                    theme === 'dark' ? 'border-slate-700' : 'border-slate-200'
+                  }`}
                 >
                   <button
                     onClick={() => setShowControl(false)}
-                    style={{
-                      position: 'absolute',
-                      top: 4,
-                      left: 4,
-                      zIndex: 10
-                    }}
+                    className={`absolute left-1 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                      theme === 'dark'
+                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                    }`}
                     aria-label="Collapse properties panel"
                   >
                     »

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -93,10 +93,10 @@ export const EditorApp: React.FC = () => {
                 >
                   <button
                     onClick={() => setShowPalette(false)}
-                    className={`absolute right-1 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                    className={`absolute right-1 top-1 z-10 rounded p-1 text-xs transition-colors ${
                       theme === 'dark'
-                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'bg-white text-slate-600 hover:bg-slate-100'
                     }`}
                     aria-label="Collapse component palette"
                   >
@@ -112,10 +112,10 @@ export const EditorApp: React.FC = () => {
                 {!showPalette && (
                   <button
                     onClick={() => setShowPalette(true)}
-                    className={`absolute left-0 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                    className={`absolute left-0 top-1 z-10 rounded p-1 text-xs transition-colors ${
                       theme === 'dark'
-                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'bg-white text-slate-600 hover:bg-slate-100'
                     }`}
                     aria-label="Expand component palette"
                   >
@@ -125,10 +125,10 @@ export const EditorApp: React.FC = () => {
                 {!showControl && (
                   <button
                     onClick={() => setShowControl(true)}
-                    className={`absolute right-0 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                    className={`absolute right-0 top-1 z-10 rounded p-1 text-xs transition-colors ${
                       theme === 'dark'
-                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'bg-white text-slate-600 hover:bg-slate-100'
                     }`}
                     aria-label="Expand properties panel"
                   >
@@ -149,10 +149,10 @@ export const EditorApp: React.FC = () => {
                 >
                   <button
                     onClick={() => setShowControl(false)}
-                    className={`absolute left-1 top-1 z-10 rounded border p-1 text-xs transition-colors ${
+                    className={`absolute left-1 top-1 z-10 rounded p-1 text-xs transition-colors ${
                       theme === 'dark'
-                        ? 'border-slate-600 bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100'
+                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                        : 'bg-white text-slate-600 hover:bg-slate-100'
                     }`}
                     aria-label="Collapse properties panel"
                   >

--- a/tests/editor-app.e2e.ts
+++ b/tests/editor-app.e2e.ts
@@ -13,11 +13,13 @@ test('renders component palette', async ({ page }) => {
 });
 
 test('renders design canvas', async ({ page }) => {
-  await expect(page.getByLabel('Design Canvas')).toBeVisible();
+  await expect(page.getByLabel('Design Canvas', { exact: true })).toBeVisible();
 });
 
 test('renders properties panel', async ({ page }) => {
-  await expect(page.getByLabel('Properties Panel')).toBeVisible();
+  await expect(
+    page.getByLabel('Properties Panel', { exact: true })
+  ).toBeVisible();
 });
 
 test('can toggle theme', async ({ page }) => {


### PR DESCRIPTION
## Summary
- restyle panel toggle buttons with Tailwind
- enforce style linting using Stylelint

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run test:e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6855a4ac86cc8331b3508c7fdee6f707