### PR TITLE
feat: improve mobile layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ A generic HTML5-based React editor built as a PWA (Progressive Web App) with com
 ## ✨ Features
 
 ### Core Functionality
+
 - **HTML5 Canvas Editor** - High-performance canvas-based editing with zoom, pan, and multi-selection
-- **Component Palette** - Drag-and-drop component library with search and categorization  
+- **Component Palette** - Drag-and-drop component library with search and categorization
 - **Property Panel** - Dynamic property editing with type-specific controls
 - **PWA Support** - Installable app with offline capabilities and service worker
 - **Responsive Design** - Mobile-first design that adapts to desktop and tablet
 
 ### Accessibility & Inclusion
+
 - **WCAG 2.1 AA Compliant** - Screen reader support, keyboard navigation, focus management
 - **Touch-First Design** - Optimized for touch devices with gesture recognition
 - **High Contrast Support** - Automatic adaptation to user contrast preferences
@@ -25,6 +27,7 @@ A generic HTML5-based React editor built as a PWA (Progressive Web App) with com
 - **Keyboard Shortcuts** - Full keyboard accessibility for power users
 
 ### Technical Features
+
 - **TypeScript** - Full type safety and excellent developer experience
 - **React 18** - Modern React with hooks and functional components
 - **Tailwind CSS** - Utility-first styling with consistent design system
@@ -34,6 +37,7 @@ A generic HTML5-based React editor built as a PWA (Progressive Web App) with com
 ## 🚀 Quick Start
 
 ### Prerequisites
+
 - Node.js 22+
 - npm 11+
 
@@ -72,22 +76,27 @@ The editor is designed mobile-first with comprehensive touch gesture support:
 - **Pinch to Zoom** - Natural zoom controls on touch devices
 - **Haptic Feedback** - Tactile feedback on supported devices
 - **Large Touch Targets** - All interactive elements meet 44px minimum size
+- **Bottom Navigation** - Palette, canvas and properties are accessible via a
+  persistent bottom tab bar on small screens
 
 ## ♿ Accessibility Features
 
 ### Screen Reader Support
+
 - Semantic HTML structure with proper ARIA labels
 - Live regions for dynamic content updates
 - Comprehensive keyboard navigation
 - Screen reader announcements for user actions
 
 ### Keyboard Navigation
+
 - **Tab/Shift+Tab** - Navigate between focusable elements
 - **Enter/Space** - Activate buttons and components
 - **Arrow Keys** - Navigate within component groups
 - **Escape** - Cancel operations and clear selections
 
 ### Visual Accessibility
+
 - High contrast mode support
 - Customizable color themes (light/dark)
 - Scalable fonts and UI elements
@@ -98,18 +107,23 @@ The editor is designed mobile-first with comprehensive touch gesture support:
 ### Core Panels
 
 #### `editor-app`
+
 Main application panel that orchestrates the canvas panel, palette panel, and control panel.
 
 #### `editor-canvas`
+
 HTML5 canvas-based editor panel with touch support, zoom/pan, and component rendering.
 
 #### `component-palette`
+
 Drag-and-drop component library panel with search, categorization, and keyboard accessibility.
 
 #### `control-panel`
+
 Dynamic property panel with type-specific controls for selected components.
 
 #### `editor-toolbar`
+
 Application toolbar with file operations, undo/redo, zoom controls, and theme toggle.
 
 ### Type System
@@ -171,6 +185,7 @@ npm run type-check   # TypeScript type checking
 ### Adding New Components
 
 1. **Define Component Type**
+
 ```typescript
 // Add to component definitions
 {
@@ -189,6 +204,7 @@ npm run type-check   # TypeScript type checking
 ```
 
 2. **Implement Rendering**
+
 ```typescript
 // Add to canvas component rendering
 case 'my-component':
@@ -197,6 +213,7 @@ case 'my-component':
 ```
 
 3. **Add Property Schema**
+
 ```typescript
 // Define editable properties
 {
@@ -224,15 +241,19 @@ The editor supports light and dark themes with CSS custom properties:
 ## 🧪 Testing
 
 ### Unit Tests
+
 ```bash
 npm run test          # Run all tests
 ```
 
 ### Accessibility Testing
+
 The project includes automated accessibility testing and follows WCAG 2.1 AA guidelines.
 
 ### Browser Testing
+
 Tested and supported on:
+
 - Chrome/Chromium 90+
 - Firefox 88+
 - Safari 14+
@@ -242,6 +263,7 @@ Tested and supported on:
 ## 📦 Deployment
 
 ### Static Hosting
+
 The built application can be deployed to any static hosting service:
 
 ```bash
@@ -250,6 +272,7 @@ npm run build
 ```
 
 ### PWA Features
+
 - **Service Worker** - Automatic caching and offline support
 - **Web App Manifest** - Installable app experience
 - **Background Sync** - Offline operation support
@@ -259,6 +282,7 @@ npm run build
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
 ### Development Setup
+
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/amazing-feature`
 3. Make your changes and add tests
@@ -268,6 +292,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 7. Open a Pull Request
 
 ### Code Standards
+
 - **ESLint** - Code linting with TypeScript rules
 - **Prettier** - Code formatting
 - **Conventional Commits** - Commit message format

--- a/src/components/editor-app/README.md
+++ b/src/components/editor-app/README.md
@@ -43,7 +43,7 @@ The component uses React hooks to manage:
 
 ## Mobile Support
 
-On mobile devices (< 768px width), the layout switches to a stacked view with tabs at the bottom for:
+On mobile devices (< 768px width), the layout shows one panel at a time. A persistent bottom navigation bar lets you switch between:
 
 - Component Palette
 - Canvas

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { useMediaQuery } from '../../utils/useMediaQuery';
 import { EditorTheme } from '../../types/editor-types';
 import type { Resolution } from '../../types/editor-types';
 import { EditorToolbar } from '../toolbar/component';
@@ -25,6 +26,10 @@ export const EditorApp: React.FC = () => {
   const [resolution, setResolution] = useState<Resolution | undefined>(
     undefined
   );
+  const isMobile = useMediaQuery('(max-width: 768px)');
+  const [mobileTab, setMobileTab] = useState<'palette' | 'canvas' | 'control'>(
+    'canvas'
+  );
 
   const handleThemeChange = useCallback(
     (e: MediaQueryListEvent | MediaQueryList) => {
@@ -32,6 +37,12 @@ export const EditorApp: React.FC = () => {
     },
     []
   );
+
+  useEffect(() => {
+    if (!isMobile) {
+      setMobileTab('canvas');
+    }
+  }, [isMobile]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
@@ -84,84 +95,142 @@ export const EditorApp: React.FC = () => {
                 onResolutionChange={setResolution}
               />
             </div>
-            <div className="relative flex flex-1 overflow-hidden">
-              {showPalette && (
-                <div
-                  className={`relative w-[250px] overflow-auto border-r ${
-                    theme === 'dark' ? 'border-slate-700' : 'border-slate-200'
+            {isMobile ? (
+              <>
+                <div className="flex-1 overflow-auto">
+                  {mobileTab === 'palette' && (
+                    <ComponentPalette
+                      theme={theme}
+                      aria-label="Component Library"
+                    />
+                  )}
+                  {mobileTab === 'canvas' && (
+                    <EditorCanvas
+                      theme={theme}
+                      resolution={resolution}
+                      aria-label="Design Canvas"
+                    />
+                  )}
+                  {mobileTab === 'control' && (
+                    <ControlPanel theme={theme} aria-label="Properties Panel" />
+                  )}
+                </div>
+                <nav
+                  className={`flex border-t ${
+                    theme === 'dark'
+                      ? 'bg-slate-700 border-slate-700'
+                      : 'bg-white border-slate-200'
                   }`}
                 >
                   <button
-                    onClick={() => setShowPalette(false)}
-                    className={`absolute right-1 top-1 z-10 rounded p-1 text-xs transition-colors ${
-                      theme === 'dark'
-                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'bg-white text-slate-600 hover:bg-slate-100'
+                    className={`flex-1 p-2 ${
+                      mobileTab === 'palette' ? 'font-semibold' : ''
                     }`}
-                    aria-label="Collapse component palette"
+                    onClick={() => setMobileTab('palette')}
+                    aria-label="Component Palette"
                   >
-                    «
+                    Palette
                   </button>
-                  <ComponentPalette
+                  <button
+                    className={`flex-1 p-2 ${
+                      mobileTab === 'canvas' ? 'font-semibold' : ''
+                    }`}
+                    onClick={() => setMobileTab('canvas')}
+                    aria-label="Canvas"
+                  >
+                    Canvas
+                  </button>
+                  <button
+                    className={`flex-1 p-2 ${
+                      mobileTab === 'control' ? 'font-semibold' : ''
+                    }`}
+                    onClick={() => setMobileTab('control')}
+                    aria-label="Properties Panel"
+                  >
+                    Props
+                  </button>
+                </nav>
+              </>
+            ) : (
+              <div className="relative flex flex-1 overflow-hidden">
+                {showPalette && (
+                  <div
+                    className={`relative w-[250px] overflow-auto border-r ${
+                      theme === 'dark' ? 'border-slate-700' : 'border-slate-200'
+                    }`}
+                  >
+                    <button
+                      onClick={() => setShowPalette(false)}
+                      className={`absolute right-1 top-1 z-10 rounded p-1 text-xs transition-colors ${
+                        theme === 'dark'
+                          ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                          : 'bg-white text-slate-600 hover:bg-slate-100'
+                      }`}
+                      aria-label="Collapse component palette"
+                    >
+                      «
+                    </button>
+                    <ComponentPalette
+                      theme={theme}
+                      aria-label="Component Library"
+                    />
+                  </div>
+                )}
+                <div className="relative flex-1 overflow-auto">
+                  {!showPalette && (
+                    <button
+                      onClick={() => setShowPalette(true)}
+                      className={`absolute left-0 top-1 z-10 rounded p-1 text-xs transition-colors ${
+                        theme === 'dark'
+                          ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                          : 'bg-white text-slate-600 hover:bg-slate-100'
+                      }`}
+                      aria-label="Expand component palette"
+                    >
+                      »
+                    </button>
+                  )}
+                  {!showControl && (
+                    <button
+                      onClick={() => setShowControl(true)}
+                      className={`absolute right-0 top-1 z-10 rounded p-1 text-xs transition-colors ${
+                        theme === 'dark'
+                          ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                          : 'bg-white text-slate-600 hover:bg-slate-100'
+                      }`}
+                      aria-label="Expand properties panel"
+                    >
+                      «
+                    </button>
+                  )}
+                  <EditorCanvas
                     theme={theme}
-                    aria-label="Component Library"
+                    resolution={resolution}
+                    aria-label="Design Canvas"
                   />
                 </div>
-              )}
-              <div className="relative flex-1 overflow-auto">
-                {!showPalette && (
-                  <button
-                    onClick={() => setShowPalette(true)}
-                    className={`absolute left-0 top-1 z-10 rounded p-1 text-xs transition-colors ${
-                      theme === 'dark'
-                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'bg-white text-slate-600 hover:bg-slate-100'
+                {showControl && (
+                  <div
+                    className={`relative w-[300px] overflow-auto border-l ${
+                      theme === 'dark' ? 'border-slate-700' : 'border-slate-200'
                     }`}
-                    aria-label="Expand component palette"
                   >
-                    »
-                  </button>
+                    <button
+                      onClick={() => setShowControl(false)}
+                      className={`absolute left-1 top-1 z-10 rounded p-1 text-xs transition-colors ${
+                        theme === 'dark'
+                          ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
+                          : 'bg-white text-slate-600 hover:bg-slate-100'
+                      }`}
+                      aria-label="Collapse properties panel"
+                    >
+                      »
+                    </button>
+                    <ControlPanel theme={theme} aria-label="Properties Panel" />
+                  </div>
                 )}
-                {!showControl && (
-                  <button
-                    onClick={() => setShowControl(true)}
-                    className={`absolute right-0 top-1 z-10 rounded p-1 text-xs transition-colors ${
-                      theme === 'dark'
-                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'bg-white text-slate-600 hover:bg-slate-100'
-                    }`}
-                    aria-label="Expand properties panel"
-                  >
-                    «
-                  </button>
-                )}
-                <EditorCanvas
-                  theme={theme}
-                  resolution={resolution}
-                  aria-label="Design Canvas"
-                />
               </div>
-              {showControl && (
-                <div
-                  className={`relative w-[300px] overflow-auto border-l ${
-                    theme === 'dark' ? 'border-slate-700' : 'border-slate-200'
-                  }`}
-                >
-                  <button
-                    onClick={() => setShowControl(false)}
-                    className={`absolute left-1 top-1 z-10 rounded p-1 text-xs transition-colors ${
-                      theme === 'dark'
-                        ? 'bg-slate-700 text-slate-200 hover:bg-slate-600'
-                        : 'bg-white text-slate-600 hover:bg-slate-100'
-                    }`}
-                    aria-label="Collapse properties panel"
-                  >
-                    »
-                  </button>
-                  <ControlPanel theme={theme} aria-label="Properties Panel" />
-                </div>
-              )}
-            </div>
+            )}
           </div>
         </SpectrumProvider>
       </I18nProvider>

--- a/src/utils/useMediaQuery.ts
+++ b/src/utils/useMediaQuery.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const getMatches = () => window.matchMedia(query).matches;
+  const [matches, setMatches] = useState(getMatches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener('change', handler);
+    setMatches(mql.matches);
+    return () => mql.removeEventListener('change', handler);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add `useMediaQuery` hook
- update `EditorApp` with mobile tab navigation
- document bottom navigation in README files

## Testing
- `npm run format` *(success)*
- `npm run lint` *(fails: Cannot find package '/workspace/open-editor-framework/node_modules/@eslint/js/index.js')*
- `npm run type-check` *(fails: Cannot find module '../lib/tsc.js')*
- `npm run test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd5a2cdc8331834035831b314683