### PR TITLE
Add compressed URL sharing

### DIFF
--- a/__tests__/editor-app.test.tsx
+++ b/__tests__/editor-app.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EditorApp } from '../src/components/editor-app/component';
+import { MemoryRouter } from 'react-router-dom';
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>
@@ -16,7 +17,11 @@ afterEach(() => {
 });
 
 test('renders the main editor application', async () => {
-  render(<EditorApp />);
+  render(
+    <MemoryRouter>
+      <EditorApp />
+    </MemoryRouter>
+  );
   const app = await screen.findByRole('application', {
     name: /react component editor/i
   });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "redux": "^5.0.1",
     "@reduxjs/toolkit": "^2.8.2",
     "react-redux": "^9.2.0",
-    "redux-undo": "^1.1.0"
+    "redux-undo": "^1.1.0",
+    "lz-string": "^1.5.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@azure/static-web-apps-cli": "^2.0.6",

--- a/src/components/editor-app/component.tsx
+++ b/src/components/editor-app/component.tsx
@@ -15,6 +15,7 @@ import { store, setComponents } from '../../store';
 import { I18nProvider } from '@react-aria/i18n';
 import { decodeComponents } from '../../utils/share';
 import type { BaseComponent } from '../../types/component-base';
+import { useSearchParams } from 'react-router-dom';
 
 /**
  * Main editor application using a simple flex layout
@@ -53,16 +54,17 @@ export const EditorApp: React.FC = () => {
     };
   }, [handleThemeChange]);
 
+  const [searchParams] = useSearchParams();
+
   useEffect(() => {
-    const params = new window.URLSearchParams(window.location.search);
-    const state = params.get('state');
+    const state = searchParams.get('state');
     if (state) {
       const components = decodeComponents(state);
       if (Array.isArray(components)) {
         store.dispatch(setComponents(components as BaseComponent[]));
       }
     }
-  }, []);
+  }, [searchParams]);
 
   const handleThemeToggle = (newTheme: EditorTheme) => {
     setTheme(newTheme);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/global.css';
 import { EditorApp } from './components/editor-app/component';
+import { BrowserRouter } from 'react-router-dom';
 
 // Register service worker for PWA functionality
 if ('serviceWorker' in navigator) {
@@ -23,6 +24,8 @@ if (!container) {
 const root = createRoot(container);
 root.render(
   <React.StrictMode>
-    <EditorApp />
+    <BrowserRouter>
+      <EditorApp />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,17 +1,22 @@
+import {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent
+} from 'lz-string';
+
 export function encodeComponents(components: unknown[]): string {
   const json = JSON.stringify(components);
-  if (typeof globalThis.btoa === 'function') {
-    return globalThis.btoa(unescape(encodeURIComponent(json)));
-  }
-  return Buffer.from(json, 'utf-8').toString('base64');
+  return compressToEncodedURIComponent(json);
 }
 
 export function decodeComponents(value: string): unknown[] | null {
   try {
-    const json =
-      typeof globalThis.atob === 'function'
-        ? decodeURIComponent(escape(globalThis.atob(value)))
-        : Buffer.from(value, 'base64').toString('utf-8');
+    let json = decompressFromEncodedURIComponent(value);
+    if (!json) {
+      json =
+        typeof globalThis.atob === 'function'
+          ? decodeURIComponent(escape(globalThis.atob(value)))
+          : Buffer.from(value, 'base64').toString('utf-8');
+    }
     return JSON.parse(json);
   } catch (_err) {
     console.warn('Failed to decode shared state');


### PR DESCRIPTION
## Summary
- compress shared canvas data using lz-string
- update EditorApp to read compressed state via React Router
- wrap app in `BrowserRouter`
- include router and lz-string dependencies
- adjust EditorApp tests for router

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856138370fc833180b01577c3f692ab