### PR TITLE
Load fallback component templates

### DIFF
--- a/__tests__/component-palette.test.tsx
+++ b/__tests__/component-palette.test.tsx
@@ -17,3 +17,10 @@ test('renders component palette container', async () => {
   const palette = await screen.findByLabelText(/component palette/i);
   expect(palette).toBeInTheDocument();
 });
+
+test('shows default components when fetch fails', async () => {
+  (fetch as jest.Mock).mockRejectedValue(new Error('network'));
+  render(<ComponentPalette theme="light" />);
+  const items = await screen.findAllByText(/Label/i);
+  expect(items.length).toBeGreaterThan(0);
+});

--- a/__tests__/useComponentTemplates.test.ts
+++ b/__tests__/useComponentTemplates.test.ts
@@ -32,4 +32,12 @@ describe('useComponentTemplates', () => {
 
     await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
   });
+
+  it('falls back to default templates on error', async () => {
+    (fetch as jest.Mock).mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useComponentTemplates('/bad.json'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.templates.length).toBeGreaterThan(0);
+    expect(result.current.error).not.toBeNull();
+  });
 });

--- a/src/samples/defaultComponentTemplates.ts
+++ b/src/samples/defaultComponentTemplates.ts
@@ -1,0 +1,59 @@
+export const defaultComponentTemplates = {
+  templates: [
+    {
+      id: 'label',
+      name: 'Label',
+      icon: '🔤',
+      description: 'Simple text label',
+      category: 'Basic',
+      template: {
+        type: 'text',
+        defaultSize: { width: 160, height: 30 },
+        properties: {
+          text: 'Label',
+          fontSize: 16,
+          fontFamily: 'Arial',
+          color: '#111827'
+        }
+      }
+    },
+    {
+      id: 'button',
+      name: 'Button',
+      icon: '🔘',
+      description: 'Interactive button component',
+      category: 'Basic',
+      template: {
+        type: 'button',
+        defaultSize: { width: 120, height: 36 },
+        properties: {
+          text: 'Button',
+          fontSize: 14,
+          fontFamily: 'Arial',
+          color: '#ffffff',
+          backgroundColor: '#3b82f6',
+          borderRadius: 4
+        }
+      }
+    },
+    {
+      id: 'container',
+      name: 'Container',
+      icon: '📦',
+      description: 'Layout container',
+      category: 'Layout',
+      template: {
+        type: 'container',
+        defaultSize: { width: 200, height: 200 },
+        properties: {
+          backgroundColor: '#f3f4f6',
+          borderColor: '#d1d5db',
+          borderWidth: 1,
+          borderRadius: 4
+        }
+      }
+    }
+  ],
+  categories: ['All', 'Basic', 'Layout']
+} as const;
+export type DefaultComponentTemplates = typeof defaultComponentTemplates;


### PR DESCRIPTION
## Summary
- add default component templates inside `src`
- map template structures in `useComponentTemplates`
- load fallback templates on fetch error
- test fallback behaviour

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run test:e2e` *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864ce268f5c833183f995fd43090081