### PR TITLE
Fix properties panel loading issue

### DIFF
--- a/src/store/canvasSlice.ts
+++ b/src/store/canvasSlice.ts
@@ -4,10 +4,12 @@ import type { BaseComponent } from '../types/component-base';
 
 export interface CanvasState {
   components: BaseComponent[];
+  selectedComponents: string[];
 }
 
 const initialState: CanvasState = {
-  components: []
+  components: [],
+  selectedComponents: []
 };
 
 export const setComponents = (components: BaseComponent[]) => ({
@@ -30,11 +32,34 @@ export const updateComponent = (component: BaseComponent) => ({
   payload: component
 });
 
+export const setSelectedComponents = (componentIds: string[]) => ({
+  type: 'canvas/setSelected' as const,
+  payload: componentIds
+});
+
+export const addSelectedComponent = (componentId: string) => ({
+  type: 'canvas/addSelected' as const,
+  payload: componentId
+});
+
+export const removeSelectedComponent = (componentId: string) => ({
+  type: 'canvas/removeSelected' as const,
+  payload: componentId
+});
+
+export const clearSelection = () => ({
+  type: 'canvas/clearSelection' as const
+});
+
 export type CanvasActions =
   | ReturnType<typeof setComponents>
   | ReturnType<typeof addComponent>
   | ReturnType<typeof removeComponent>
-  | ReturnType<typeof updateComponent>;
+  | ReturnType<typeof updateComponent>
+  | ReturnType<typeof setSelectedComponents>
+  | ReturnType<typeof addSelectedComponent>
+  | ReturnType<typeof removeSelectedComponent>
+  | ReturnType<typeof clearSelection>;
 
 const reducer = (
   state: CanvasState = initialState,
@@ -48,7 +73,8 @@ const reducer = (
     case 'canvas/remove':
       return {
         ...state,
-        components: state.components.filter((c) => c.id !== action.payload)
+        components: state.components.filter((c) => c.id !== action.payload),
+        selectedComponents: state.selectedComponents.filter(id => id !== action.payload)
       };
     case 'canvas/update':
       return {
@@ -57,6 +83,20 @@ const reducer = (
           c.id === action.payload.id ? action.payload : c
         )
       };
+    case 'canvas/setSelected':
+      return { ...state, selectedComponents: action.payload };
+    case 'canvas/addSelected':
+      return {
+        ...state,
+        selectedComponents: [...state.selectedComponents, action.payload]
+      };
+    case 'canvas/removeSelected':
+      return {
+        ...state,
+        selectedComponents: state.selectedComponents.filter(id => id !== action.payload)
+      };
+    case 'canvas/clearSelection':
+      return { ...state, selectedComponents: [] };
     default:
       return state;
   }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable properties panel to display selected component properties by centralizing component selection state in Redux.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the selected component state was managed locally within the `EditorCanvas` component, preventing other components like the `ControlPanel` from accessing and reacting to the current selection. This PR moves the `selectedComponents` state into the Redux store, allowing the `ControlPanel` to subscribe to these changes and dynamically render the properties of the currently selected component.