### PR TITLE
Fix duplicate child parent id handling

### DIFF
--- a/__tests__/component-helper.test.ts
+++ b/__tests__/component-helper.test.ts
@@ -1,0 +1,38 @@
+import { ComponentHelper } from '../src/utils/helpers';
+import { BaseComponent } from '../src/types/component-base';
+
+function createParentWithChild() {
+  const child = new BaseComponent({
+    id: 'child',
+    type: 'text',
+    name: 'Child',
+    bounds: { x: 0, y: 0, width: 10, height: 10 },
+    parent: 'parent',
+    children: []
+  });
+  const parent = new BaseComponent({
+    id: 'parent',
+    type: 'container',
+    name: 'Parent',
+    bounds: { x: 0, y: 0, width: 20, height: 20 },
+    children: [child]
+  });
+  child.parent = parent.id;
+  return { parent, child };
+}
+
+describe('ComponentHelper.duplicateComponent', () => {
+  test('updates parent id of duplicated children', () => {
+    const { parent, child } = createParentWithChild();
+    const duplicate = ComponentHelper.duplicateComponent(parent, {
+      x: 0,
+      y: 0
+    });
+
+    expect(duplicate.id).not.toBe(parent.id);
+    expect(duplicate.children).toHaveLength(1);
+    const dupChild = duplicate.children![0];
+    expect(dupChild.id).not.toBe(child.id);
+    expect(dupChild.parent).toBe(duplicate.id);
+  });
+});

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -96,21 +96,24 @@ export class ComponentHelper {
     component: BaseComponent,
     offset: Point = { x: 20, y: 20 }
   ): BaseComponent {
-    const duplicate = new BaseComponent({
+    const newId = this.generateId();
+    const children = component.children?.map((child) => {
+      const dupChild = this.duplicateComponent(child, offset);
+      dupChild.parent = newId;
+      return dupChild;
+    });
+
+    return new BaseComponent({
       ...component,
-      id: this.generateId(),
+      id: newId,
       bounds: {
         ...component.bounds,
         x: component.bounds.x + offset.x,
         y: component.bounds.y + offset.y
       },
       properties: { ...component.properties },
-      children: component.children?.map((child) =>
-        this.duplicateComponent(child, offset)
-      )
+      children
     });
-
-    return duplicate;
   }
 
   static isPointInBounds(


### PR DESCRIPTION
## Summary
- write regression test for ComponentHelper.duplicateComponent
- fix duplicateComponent so duplicated children reference the new parent's id

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68659db011b88331baa2d7fe378c625a