### PR TITLE
Implement canvas events

### DIFF
--- a/src/components/editor-canvas/component.tsx
+++ b/src/components/editor-canvas/component.tsx
@@ -370,17 +370,22 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({
     }
 
     // Update component position
-    dispatch(
-      updateComponent(
-        new BaseComponent({
-          ...component,
-          bounds: {
-            ...component.bounds,
-            x: constrainedX,
-            y: constrainedY
-          }
-        })
-      )
+    const updated = new BaseComponent({
+      ...component,
+      bounds: {
+        ...component.bounds,
+        x: constrainedX,
+        y: constrainedY
+      }
+    });
+    dispatch(updateComponent(updated));
+    window.dispatchEvent(
+      new window.CustomEvent('component-move', {
+        detail: {
+          component: updated,
+          position: { x: constrainedX, y: constrainedY }
+        }
+      })
     );
   };
 
@@ -391,6 +396,15 @@ export const EditorCanvas: React.FC<EditorCanvasProps> = ({
   const handleRedo = useCallback(() => {
     dispatch(ActionCreators.redo());
   }, [dispatch]);
+
+  // Emit selection change events
+  useEffect(() => {
+    window.dispatchEvent(
+      new window.CustomEvent('selection-change', {
+        detail: { selectedComponents: canvasState.selectedComponents }
+      })
+    );
+  }, [canvasState.selectedComponents]);
 
   const initializeCanvas = useCallback(() => {
     const canvas = canvasRef.current;


### PR DESCRIPTION
## Summary
- emit `component-move` event when dragging ends
- dispatch `selection-change` when selection updates

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6865a3312690833198b02a3669f8d5ab