### PR TITLE
feat: add developer settings screen

### DIFF
--- a/__tests__/developer-settings.test.tsx
+++ b/__tests__/developer-settings.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeveloperSettings from '../src/components/developer-settings';
+
+describe('DeveloperSettings', () => {
+  it('allows editing environment variables', () => {
+    render(<DeveloperSettings initialEnv={{ FOO: 'bar' }} />);
+    const input = screen.getByLabelText('FOO');
+    expect(input).toHaveValue('bar');
+    fireEvent.change(input, { target: { value: 'baz' } });
+    expect(input).toHaveValue('baz');
+  });
+});

--- a/src/components/developer-settings/README.md
+++ b/src/components/developer-settings/README.md
@@ -1,0 +1,18 @@
+# Developer Settings
+
+A screen for editing environment variables and interacting with the server via a simple terminal.
+
+## Features
+
+- Editable environment variable form fields.
+- WebSocket-driven terminal for sending commands to the server.
+
+## Usage
+
+```tsx
+import DeveloperSettings from './components/developer-settings';
+
+export function SettingsPage() {
+  return <DeveloperSettings />;
+}
+```

--- a/src/components/developer-settings/component.tsx
+++ b/src/components/developer-settings/component.tsx
@@ -1,0 +1,88 @@
+/* global HTMLPreElement, WebSocket, location */
+import { KeyboardEvent, useEffect, useRef, useState } from 'react';
+
+export interface DeveloperSettingsProps {
+  initialEnv?: Record<string, string>;
+}
+
+export default function DeveloperSettings({
+  initialEnv
+}: DeveloperSettingsProps) {
+  const [envVars, setEnvVars] = useState<Record<string, string>>(() => {
+    if (initialEnv) return initialEnv;
+    const source = (process.env ?? {}) as Record<string, string>;
+    const entries = Object.entries(source).filter(
+      ([_, value]) => typeof value === 'string'
+    ) as [string, string][];
+    return Object.fromEntries(entries);
+  });
+
+  const handleEnvChange = (key: string, value: string) => {
+    setEnvVars((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const outputRef = useRef<HTMLPreElement>(null);
+  const [command, setCommand] = useState('');
+  const wsUrl =
+    (process.env.VITE_TERMINAL_WS_URL as string | undefined) ||
+    `ws://${location.host}/api/terminal`;
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+    ws.onmessage = (event) => {
+      if (outputRef.current) {
+        outputRef.current.textContent += `\n${event.data}`;
+        outputRef.current.scrollTop = outputRef.current.scrollHeight;
+      }
+    };
+    return () => ws.close();
+  }, [wsUrl]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      wsRef.current?.send(command);
+      setCommand('');
+    }
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <section>
+        <h2 className="text-lg font-bold mb-2">Environment Variables</h2>
+        <form className="flex flex-col gap-2">
+          {Object.entries(envVars).map(([key, value]) => (
+            <label key={key} className="flex items-center gap-2">
+              <span className="w-32" aria-hidden="true">
+                {key}
+              </span>
+              <input
+                aria-label={key}
+                className="flex-1 border p-1 rounded"
+                value={value}
+                onChange={(e) => handleEnvChange(key, e.target.value)}
+              />
+            </label>
+          ))}
+        </form>
+      </section>
+      <section>
+        <h2 className="text-lg font-bold mb-2">Terminal</h2>
+        <pre
+          ref={outputRef}
+          aria-label="terminal-output"
+          className="h-48 overflow-auto bg-black text-green-300 p-2 rounded"
+        />
+        <input
+          aria-label="terminal-input"
+          className="w-full border p-1 mt-2 rounded"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/components/developer-settings/component.tsx
+++ b/src/components/developer-settings/component.tsx
@@ -37,6 +37,18 @@ export default function DeveloperSettings({
         outputRef.current.scrollTop = outputRef.current.scrollHeight;
       }
     };
+    ws.onerror = (event) => {
+      if (outputRef.current) {
+        outputRef.current.textContent += `\n[WebSocket error: connection problem]`;
+        outputRef.current.scrollTop = outputRef.current.scrollHeight;
+      }
+    };
+    ws.onclose = (event) => {
+      if (outputRef.current) {
+        outputRef.current.textContent += `\n[WebSocket closed]`;
+        outputRef.current.scrollTop = outputRef.current.scrollHeight;
+      }
+    };
     return () => ws.close();
   }, [wsUrl]);
 

--- a/src/components/developer-settings/index.ts
+++ b/src/components/developer-settings/index.ts
@@ -1,0 +1,2 @@
+export { default } from './component';
+export type { DeveloperSettingsProps } from './component';


### PR DESCRIPTION
## Summary
- add Developer Settings component with editable env vars and websocket terminal
- cover env var editing with tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68bf6b2a6b4083319094a1f37a66e702